### PR TITLE
Unify local acceptance tests and travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,14 @@ go:
   - "1.18.x"
 
 env:
-  - DB=mysql:5.6 DB_EXTRA=''
-  - DB=mysql:5.7 DB_EXTRA=''
-  - DB=mysql:8.0 DB_EXTRA='mysqld --default-authentication-plugin=mysql_native_password'
+  - TARGET=testversion5.6
+  - TARGET=testversion5.7
+  - TARGET=testversion8.0
+  - TARGET=testpercona5.7
+  - TARGET=testpercona8.0
+  - TARGET=testmariadb10.3
+  - TARGET=testmariadb10.8
+  - TARGET=testtidb6.1.0
 
 services:
   - docker
@@ -19,22 +24,7 @@ script:
   - test -d /home/travis/gopath/src/github.com/terraform-providers || mv $(dirname $PWD) /home/travis/gopath/src/github.com/terraform-providers
   - make test
   - make vet
-  - sudo service mysql stop
-  - export MYSQL_HOST=127.0.0.1
-  - export MYSQL_PORT=3306
-  - export MYSQL_USERNAME=root
-  - export MYSQL_ENDPOINT="${MYSQL_HOST}:${MYSQL_PORT}"
-  - export MYSQL_PASSWORD=''
-  - docker pull $DB
-  - docker run -d -p ${MYSQL_HOST}:${MYSQL_PORT}:${MYSQL_PORT} -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -e MYSQL_ROOT_PASSWORD='' $DB $DB_EXTRA
-  - docker ps -a
-  - |
-    while ! mysql -h${MYSQL_HOST} -P${MYSQL_PORT} -u${MYSQL_USERNAME} -e 'SELECT 1'; do
-      echo 'Waiting for MySQL...'
-      sleep 1;
-    done;
-  - mysql -h${MYSQL_HOST} -P${MYSQL_PORT} -u${MYSQL_USERNAME} -e "INSTALL PLUGIN mysql_no_login SONAME 'mysql_no_login.so';"
-  - make testacc
+  - make "${TARGET}"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
For parallelism, I'm separating the targets here. But we could do it
with just one call to "make acceptance"