### PR TITLE
Make database optional in grant resource

### DIFF
--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -59,7 +59,7 @@ func resourceGrant() *schema.Resource {
 
 			"database": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
 

--- a/website/docs/r/grant.html.markdown
+++ b/website/docs/r/grant.html.markdown
@@ -58,7 +58,7 @@ resource "mysql_role" "developer" {
 resource "mysql_grant" "developer" {
   user     = mysql_user.jdoe.user
   host     = mysql_user.jdoe.host
-  database = "app"
+  database = "app"                   #Optional
   roles    = [mysql_role.developer.name]
 }
 ```


### PR DESCRIPTION
Hey guys,

i don't have much experience with go and in developing terraform providers.
I wanted to use this provider to create a simple privilige management.
I've discovered the problem that if you want to grant a role to a user, you must define a database for the grant resource.
This isn't needed by the latest mysql and mariadb versions (tested).
A sample in the MariaDB documentation is [here](https://mariadb.com/kb/en/roles_overview/#roles-and-views-and-stored-routines).

So i changed the line in the code which declares the database as required and changed it to optional.

I hope i did everything the right way.

Greets
Carl