### PR TITLE
fix: strconv.Atoi: strconv.Atoi: parsing "": invalid syntax

### DIFF
--- a/mysql/resource_rds_config.go
+++ b/mysql/resource_rds_config.go
@@ -106,7 +106,7 @@ func ReadRDSConfig(ctx context.Context, d *schema.ResourceData, meta interface{}
 		}
 	}
 
-	if len(results["binlog retention hours"]) == 0 {
+	if len(results["binlog retention hours"]) == 0 || results["binlog retention hours"] == "NULL" {
 		results["binlog retention hours"] = "0"
 	}
 

--- a/mysql/resource_rds_config.go
+++ b/mysql/resource_rds_config.go
@@ -103,15 +103,22 @@ func ReadRDSConfig(ctx context.Context, d *schema.ResourceData, meta interface{}
 
 		if value.Valid {
 			results[name] = value.String
-		} else {
-			results[name] = "0"
 		}
+	}
+
+	if len(results["binlog retention hours"]) == 0 {
+		results["binlog retention hours"] = "0"
 	}
 
 	binlogRetentionPeriod, err := strconv.Atoi(results["binlog retention hours"])
 	if err != nil {
 		return diag.Errorf("failed reading binlog retention hours in RDS config: %v", err)
 	}
+
+	if len(results["target delay"]) == 0 {
+		results["target delay"] = "0"
+	}
+
 	replicationTargetDelay, err := strconv.Atoi(results["target delay"])
 	if err != nil {
 		return diag.Errorf("failed reading target delay in RDS config: %v", err)

--- a/mysql/resource_rds_config_test.go
+++ b/mysql/resource_rds_config_test.go
@@ -178,15 +178,22 @@ func testAccRDSCheck_full(rn string, binlogUpdated, targetDelayUpdated int) reso
 
 			if value.Valid {
 				results[name] = value.String
-			} else {
-				results[name] = "0"
 			}
+		}
+
+		if len(results["binlog retention hours"]) == 0 {
+			results["binlog retention hours"] = "0"
 		}
 
 		binlogRetentionPeriod, err := strconv.Atoi(results["binlog retention hours"])
 		if err != nil {
 			return fmt.Errorf("failed reading binlog retention RDS config: %v", err)
 		}
+
+		if len(results["target delay"]) == 0 {
+			results["target delay"] = "0"
+		}
+
 		replicationTargetDelay, err := strconv.Atoi(results["target delay"])
 		if err != nil {
 			return fmt.Errorf("failed reading target delay RDS config: %v", err)

--- a/mysql/resource_rds_config_test.go
+++ b/mysql/resource_rds_config_test.go
@@ -181,7 +181,7 @@ func testAccRDSCheck_full(rn string, binlogUpdated, targetDelayUpdated int) reso
 			}
 		}
 
-		if len(results["binlog retention hours"]) == 0 {
+		if len(results["binlog retention hours"]) == 0 || results["binlog retention hours"] == "NULL" {
 			results["binlog retention hours"] = "0"
 		}
 


### PR DESCRIPTION
The else only works if there is a row in the config. 

But if there is no existing value set it is a empty string and it can not convert to integer. 

`Error: failed reading target delay in RDS config: strconv.Atoi: parsing "": invalid syntax`