### PR TITLE
Add support for CREATE AADUSER to mysql_user resource

### DIFF
--- a/mysql/resource_user.go
+++ b/mysql/resource_user.go
@@ -181,16 +181,17 @@ func CreateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		return diag.Errorf("failed executing SQL: %v", err)
 	}
 
+	user := fmt.Sprintf("%s@%s", d.Get("user").(string), d.Get("host").(string))
+	d.SetId(user)
+
 	if updateStmtSql != "" {
 		log.Println("Executing statement:", updateStmtSql)
 		_, err = db.ExecContext(ctx, updateStmtSql)
 		if err != nil {
+			d.Set("tls_option", "")
 			return diag.Errorf("failed executing SQL: %v", err)
 		}
 	}
-
-	user := fmt.Sprintf("%s@%s", d.Get("user").(string), d.Get("host").(string))
-	d.SetId(user)
 
 	return nil
 }

--- a/mysql/resource_user.go
+++ b/mysql/resource_user.go
@@ -125,13 +125,13 @@ func CreateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 
 	if createObj == "AADUSER" {
 		if _, uuidErr := uuid.Parse(d.Get("aad_identity").(string)); uuidErr == nil {
-			// CREATE AADUSER "mysqlProtocolLoginName"@"mysqlHostRestriction" IDENTIFIED BY "identityId"
+			// CREATE AADUSER 'mysqlProtocolLoginName"@"mysqlHostRestriction' IDENTIFIED BY 'identityId'
 			stmtSQL = fmt.Sprintf("CREATE AADUSER '%s'@'%s' IDENTIFIED BY '%s'",
 				d.Get("user").(string),
 				d.Get("host").(string),
 				d.Get("aad_identity").(string))
 		} else {
-			// CREATE AADUSER "identityName"@"mysqlHostRestriction" AS "mysqlProtocolLoginName"
+			// CREATE AADUSER 'identityName"@"mysqlHostRestriction' AS 'mysqlProtocolLoginName'
 			stmtSQL = fmt.Sprintf("CREATE AADUSER '%s'@'%s' AS '%s'",
 				d.Get("aad_identity").(string),
 				d.Get("host").(string),

--- a/mysql/resource_user.go
+++ b/mysql/resource_user.go
@@ -72,6 +72,7 @@ func resourceUser() *schema.Resource {
 				Optional:         true,
 				Sensitive:        true,
 				DiffSuppressFunc: NewEmptyStringSuppressFunc,
+				ConflictsWith:    []string{"plaintext_password", "password"},
 			},
 
 			"tls_option": {

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -53,7 +53,10 @@ resource "mysql_user" "nologin" {
 resource "mysql_user" "aadupn" {
   user = "aliasToUseWhenConnectiong"
   auth_plugin = "aad_auth"
-  aad_identity = "little.johny@doe.onmicrosoft.com"
+  aad_identity {
+    type = "user" # user | group | service_principal
+    identity = "little.johny@doe.onmicrosoft.com" # upn | group name | client id of service principal
+  }
 }
 ```
 
@@ -67,7 +70,7 @@ The following arguments are supported:
 * `password` - (Optional) Deprecated alias of `plaintext_password`, whose value is *stored as plaintext in state*. Prefer to use `plaintext_password` instead, which stores the password as an unsalted hash. Conflicts with `auth_plugin`.
 * `auth_plugin` - (Optional) Use an [authentication plugin][ref-auth-plugins] to authenticate the user instead of using password authentication.  Description of the fields allowed in the block below. Conflicts with `password` and `plaintext_password`.  
 * `auth_string_hashed` - (Optional) Use an already hashed string as a parameter to `auth_plugin`. This can be used with passwords as well as with other auth strings.
-* `aad_identity` - (Optional) Required when `auth_plugin` is `aad_auth`. This should contain either UPN of user, name of AAD Group or Client ID of service principal.
+* `aad_identity` - (Optional) Required when `auth_plugin` is `aad_auth`. This should be block containing `type` and `identity`. `type` can be one of `user`, `group` and `service_principal`. `identity` then should containt either UPN of user, name of group or Client ID of service principal.
 * `tls_option` - (Optional) An TLS-Option for the `CREATE USER` or `ALTER USER` statement. The value is suffixed to `REQUIRE`. A value of 'SSL' will generate a `CREATE USER ... REQUIRE SSL` statement. See the [MYSQL `CREATE USER` documentation](https://dev.mysql.com/doc/refman/5.7/en/create-user.html) for more. Ignored if MySQL version is under 5.7.0.
 
 [ref-auth-plugins]: https://dev.mysql.com/doc/refman/5.7/en/authentication-plugins.html

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -47,6 +47,16 @@ resource "mysql_user" "nologin" {
 }
 ```
 
+## Example Usage with AzureAD Authentication Plugin
+
+```hcl
+resource "mysql_user" "aadupn" {
+  user = "aliasToUseWhenConnectiong"
+  auth_plugin = "aad_auth"
+  aad_identity = "little.johny@doe.onmicrosoft.com"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -57,6 +67,7 @@ The following arguments are supported:
 * `password` - (Optional) Deprecated alias of `plaintext_password`, whose value is *stored as plaintext in state*. Prefer to use `plaintext_password` instead, which stores the password as an unsalted hash. Conflicts with `auth_plugin`.
 * `auth_plugin` - (Optional) Use an [authentication plugin][ref-auth-plugins] to authenticate the user instead of using password authentication.  Description of the fields allowed in the block below. Conflicts with `password` and `plaintext_password`.  
 * `auth_string_hashed` - (Optional) Use an already hashed string as a parameter to `auth_plugin`. This can be used with passwords as well as with other auth strings.
+* `aad_identity` - (Optional) Required when `auth_plugin` is `aad_auth`. This should contain either UPN of user, name of AAD Group or Client ID of service principal.
 * `tls_option` - (Optional) An TLS-Option for the `CREATE USER` or `ALTER USER` statement. The value is suffixed to `REQUIRE`. A value of 'SSL' will generate a `CREATE USER ... REQUIRE SSL` statement. See the [MYSQL `CREATE USER` documentation](https://dev.mysql.com/doc/refman/5.7/en/create-user.html) for more. Ignored if MySQL version is under 5.7.0.
 
 [ref-auth-plugins]: https://dev.mysql.com/doc/refman/5.7/en/authentication-plugins.html
@@ -75,6 +86,14 @@ The `auth_plugin` value supports:
   see [here][ref-mysql-no-login].
 
 [ref-mysql-no-login]: https://dev.mysql.com/doc/refman/5.7/en/no-login-pluggable-authentication.html
+
+* `aad_auth` - Uses `CREATE AADUSER` statement to create user instead of `CREATE USER` to create user
+   with [AzureAD authentication][ref-azure-aadauth] to [Azure Database for MySQL][ref-azure-mysql].
+   When specified, you need to specify `aad_identity`. For more information about AzureAD authentication into MySQL  
+   see [here][ref-azure-aadauth]. You have to use AAD authenticated administrator mysql session to use this plugin.
+
+[ref-azure-aadauth]: https://learn.microsoft.com/en-us/azure/mysql/flexible-server/how-to-azure-ad
+[ref-azure-mysql]: https://learn.microsoft.com/en-us/azure/mysql/
 
 * any other auth plugin supported by MySQL.
 ## Attributes Reference


### PR DESCRIPTION
Supports creating users authorized by AzureAD tokens instead of passwords https://learn.microsoft.com/en-us/azure/mysql/flexible-server/concepts-azure-ad-authentication

Although aad_auth is MySQL plugin and there is theoretical possibility to use `CREATE USER ... IDENTIFIED WITH 'aad_auth' AS 'AADUser:objectid:upn:objectname' `, this is currently not documented solution. As aad_auth is in public preview only, there is no guarantee this command would work.

Therefore I tried to follow documentation and implement Microsoft specific `CREATE AADUSER` command as much as possible complying with documentation.

What this PR can do:

```
resource mysql_user {
    user = "someuser" # name used to login to MySQL - in Microsoft's documentation it's alias (CREATE AADUSER x AS alias)
    auth_plugin = "aad_auth"
    aad_identity = "some.user@exampe.onmicrosoft.com"
}
```
Leads to `CREATE AADUSER 'some.user@exampe.onmicrosoft.com'@'localhost' AS 'someuser'`

- Using `@hostname` in this statement is undocumented by Microsoft, but works. Microsoft defualts it to `%` when ommited and it's up to everyone if he will try to use it another way
- If someone needs to use user without alias, he has to set `user` to equal `aad_identity` what is Microsoft's defaults
- Instead of user principal name in `aad_identity`, there is allowed group name, which then works same as for user principals.
- To work for Service principal, there has to be it's Client ID in `aad_identity` which then leads to query `CREATE AADUSER alias@hostname IDENTIFIED BY clientid` which is stupid, but it's according to something i found on Microsoft's support.
- Nothing stops user to use object id instead of upn's or group names, but this would break import/refresh of this users as using object id for theese identity types are not suported by Microsoft's documentation

Only thing, where I depend on authentication data is in import, where I parse it back to `aad_identity`


I did not wrote any tests of `auth_plugin = aad_auth`  since I don't know if there is any possibility to run them in pipeline then as `CREATE AADUSER` is supported only in Azure managed servers.

I'm aware, that code is not nice, I tried above explain why. If you think, it can be improoved, please show me direction and I will try to do my best.