### PR TITLE
Support dynamic grants in MySQL8

### DIFF
--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -241,10 +241,9 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 func afterConnectVersion(ctx context.Context, mysqlConf *MySQLConfiguration, db *sql.DB) (*version.Version, error) {
 	// Set up env so that we won't create users randomly.
-	fmt.Printf("AAA Running after connect\n")
 	currentVersion, err := serverVersion(db)
 	if err != nil {
-		return nil, fmt.Errorf("Failed getting server version: %v", err)
+		return nil, fmt.Errorf("failed getting server version: %v", err)
 	}
 
 	versionMinInclusive, _ := version.NewVersion("5.7.5")

--- a/mysql/provider_test.go
+++ b/mysql/provider_test.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/go-version"
 	"os"
 	"strings"
 	"testing"
@@ -146,6 +147,28 @@ func testAccPreCheckSkipMariaDB(t *testing.T) {
 
 	if strings.Contains(currentVersionString, "MariaDB") {
 		t.Skip("Skip on MariaDB")
+	}
+}
+
+func testAccPreCheckSkipNotMySQL8(t *testing.T) {
+	testAccPreCheck(t)
+
+	ctx := context.Background()
+	db, err := connectToMySQL(ctx, testAccProvider.Meta().(*MySQLConfiguration))
+	if err != nil {
+		t.Fatalf("Cannot connect to DB (SkipNotMySQL8): %v", err)
+		return
+	}
+
+	currentVersion, err := serverVersion(db)
+	if err != nil {
+		t.Fatalf("Cannot get DB version string (SkipNotMySQL8): %v", err)
+		return
+	}
+
+	versionMin, _ := version.NewVersion("8.0.0")
+	if currentVersion.LessThan(versionMin) {
+		t.Skip("Skip on MySQL8")
 	}
 }
 

--- a/website/docs/r/grant.html.markdown
+++ b/website/docs/r/grant.html.markdown
@@ -90,7 +90,13 @@ No further attributes are exported.
 Grants can be imported using user, host, database and table.
 For grants without explicit database or tables, leave these fields empty.
 
+You can also add an extra at sign `@` to the import definition to specify
+the grant contains WITH GRANT OPTION.
+
 ```
 $ terraform import mysql_grant.example user@host@database@table
 $ terraform import mysql_grant.without_db user@host@@
+
+# Import the first example with grant option
+$ terraform import mysql_grant.example user@host@database@table@
 ```


### PR DESCRIPTION
It seems dynamic grants in MySQL8 don't obey the original grant model, where SHOW GRANTS shows them in 1 row.

Instead, there are 2 rows - one for static grants like SELECT and one for dynamic grants.

I added test and started merging all grants to make sure we get everything here.

As the new test works now (and didn't work before), I am reasonably convinced this works.