### PR TITLE
feat: add retain old password support

### DIFF
--- a/mysql/provider_test.go
+++ b/mysql/provider_test.go
@@ -172,6 +172,28 @@ func testAccPreCheckSkipNotMySQL8(t *testing.T) {
 	}
 }
 
+func testAccPreCheckSkipNotMySQLVersionMin(t *testing.T, minVersion string) {
+	testAccPreCheck(t)
+
+	ctx := context.Background()
+	db, err := connectToMySQL(ctx, testAccProvider.Meta().(*MySQLConfiguration))
+	if err != nil {
+		t.Fatalf("Cannot connect to DB (SkipNotMySQLVersionMin): %v", err)
+		return
+	}
+
+	currentVersion, err := serverVersion(db)
+	if err != nil {
+		t.Fatalf("Cannot get DB version string (SkipNotMySQLVersionMin): %v", err)
+		return
+	}
+
+	versionMin, _ := version.NewVersion(minVersion)
+	if currentVersion.LessThan(versionMin) {
+		t.Skipf("Skip on MySQL version less than %s", minVersion)
+	}
+}
+
 func testAccPreCheckSkipNotTiDB(t *testing.T) {
 	testAccPreCheck(t)
 

--- a/mysql/resource_grant_test.go
+++ b/mysql/resource_grant_test.go
@@ -231,7 +231,7 @@ func TestAccGrantComplexMySQL8(t *testing.T) {
 			testAccPreCheckSkipTiDB(t)
 			testAccPreCheckSkipRds(t)
 			testAccPreCheckSkipMariaDB(t)
-			testAccPreCheckSkipNotMySQL8(t)
+			testAccPreCheckSkipNotMySQLVersionMin(t, "8.0.0")
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGrantCheckDestroy,
@@ -262,7 +262,7 @@ func TestAccGrant_role(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckSkipRds(t)
-			testAccPreCheckSkipNotMySQL8(t)
+			testAccPreCheckSkipNotMySQLVersionMin(t, "8.0.0")
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGrantCheckDestroy,
@@ -296,7 +296,7 @@ func TestAccGrant_roleToUser(t *testing.T) {
 		PreCheck: func() {
 			testAccPreCheck(t)
 			testAccPreCheckSkipRds(t)
-			testAccPreCheckSkipNotMySQL8(t)
+			testAccPreCheckSkipNotMySQLVersionMin(t, "8.0.0")
 		},
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGrantCheckDestroy,

--- a/mysql/resource_user.go
+++ b/mysql/resource_user.go
@@ -110,12 +110,12 @@ func resourceUser() *schema.Resource {
 	}
 }
 
-func checkRetainCurrentPasswordSupport(ctx context.Context, meta interface{}) (bool, error) {
+func checkRetainCurrentPasswordSupport(ctx context.Context, meta interface{}) error {
 	ver, _ := version.NewVersion("8.0.14")
 	if getVersionFromMeta(ctx, meta).LessThan(ver) {
-		return false, errors.New("cannot use retain_current_password with MySQL version < 8.0.14")
+		return errors.New("MySQL version must be at least 8.0.14")
 	}
-	return true, nil
+	return nil
 }
 
 func CreateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -214,9 +214,9 @@ func CreateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 
 	retainPassword := d.Get("retain_old_password").(bool)
 	if retainPassword {
-		_, err := checkRetainCurrentPasswordSupport(ctx, meta)
+		err := checkRetainCurrentPasswordSupport(ctx, meta)
 		if err != nil {
-			return diag.Errorf("%v", err)
+			return diag.Errorf("cannot use retain_current_password: %v", err)
 		}
 	}
 
@@ -298,9 +298,9 @@ func UpdateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 
 	retainPassword := d.Get("retain_old_password").(bool)
 	if retainPassword {
-		_, err := checkRetainCurrentPasswordSupport(ctx, meta)
+		err := checkRetainCurrentPasswordSupport(ctx, meta)
 		if err != nil {
-			return diag.Errorf("%v", err)
+			return diag.Errorf("cannot use retain_current_password: %v", err)
 		}
 	}
 

--- a/mysql/resource_user.go
+++ b/mysql/resource_user.go
@@ -2,15 +2,16 @@ package mysql
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"log"
 	"regexp"
 	"strings"
 
 	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceUser() *schema.Resource {
@@ -100,8 +101,21 @@ func resourceUser() *schema.Resource {
 				Optional: true,
 				Default:  "NONE",
 			},
+
+			"retain_old_password": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
+}
+
+func checkRetainCurrentPasswordSupport(ctx context.Context, meta interface{}) (bool, error) {
+	ver, _ := version.NewVersion("8.0.14")
+	if getVersionFromMeta(ctx, meta).LessThan(ver) {
+		return false, errors.New("cannot use retain_current_password with MySQL version < 8.0.14")
+	}
+	return true, nil
 }
 
 func CreateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -198,6 +212,14 @@ func CreateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		}
 	}
 
+	retainPassword := d.Get("retain_old_password").(bool)
+	if retainPassword {
+		_, err := checkRetainCurrentPasswordSupport(ctx, meta)
+		if err != nil {
+			return diag.Errorf("%v", err)
+		}
+	}
+
 	log.Println("Executing statement:", stmtSQL)
 	_, err = db.ExecContext(ctx, stmtSQL)
 	if err != nil {
@@ -219,14 +241,18 @@ func CreateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	return nil
 }
 
-func getSetPasswordStatement(ctx context.Context, meta interface{}) (string, error) {
+func getSetPasswordStatement(ctx context.Context, meta interface{}, retainPassword bool) (string, error) {
+	if retainPassword {
+		return "ALTER USER ?@? IDENTIFIED BY ? RETAIN CURRENT PASSWORD", nil
+	}
+
 	/* ALTER USER syntax introduced in MySQL 5.7.6 deprecates SET PASSWORD (GH-8230) */
 	ver, _ := version.NewVersion("5.7.6")
 	if getVersionFromMeta(ctx, meta).LessThan(ver) {
 		return "SET PASSWORD FOR ?@? = PASSWORD(?)", nil
-	} else {
-		return "ALTER USER ?@? IDENTIFIED BY ?", nil
 	}
+
+	return "ALTER USER ?@? IDENTIFIED BY ?", nil
 }
 
 func UpdateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -270,8 +296,16 @@ func UpdateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		newpw = nil
 	}
 
+	retainPassword := d.Get("retain_old_password").(bool)
+	if retainPassword {
+		_, err := checkRetainCurrentPasswordSupport(ctx, meta)
+		if err != nil {
+			return diag.Errorf("%v", err)
+		}
+	}
+
 	if newpw != nil {
-		stmtSQL, err := getSetPasswordStatement(ctx, meta)
+		stmtSQL, err := getSetPasswordStatement(ctx, meta, retainPassword)
 		if err != nil {
 			return diag.Errorf("failed getting change password statement: %v", err)
 		}

--- a/mysql/resource_user_password.go
+++ b/mysql/resource_user_password.go
@@ -61,9 +61,9 @@ func SetUserPassword(ctx context.Context, d *schema.ResourceData, meta interface
 
 	retainPassword := d.Get("retain_old_password").(bool)
 	if retainPassword {
-		_, err := checkRetainCurrentPasswordSupport(ctx, meta)
+		err := checkRetainCurrentPasswordSupport(ctx, meta)
 		if err != nil {
-			return diag.Errorf("%v", err)
+			return diag.Errorf("cannot use retain_current_password: %v", err)
 		}
 	}
 

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -73,6 +73,7 @@ The following arguments are supported:
 * `auth_plugin` - (Optional) Use an [authentication plugin][ref-auth-plugins] to authenticate the user instead of using password authentication.  Description of the fields allowed in the block below. Conflicts with `password` and `plaintext_password`.  
 * `auth_string_hashed` - (Optional) Use an already hashed string as a parameter to `auth_plugin`. This can be used with passwords as well as with other auth strings.
 * `aad_identity` - (Optional) Required when `auth_plugin` is `aad_auth`. This should be block containing `type` and `identity`. `type` can be one of `user`, `group` and `service_principal`. `identity` then should containt either UPN of user, name of group or Client ID of service principal.
+* `retain_old_password` - (Optional) When `true`, the old password is retained when changing the password. Defaults to `false`. This use MySQL Dual Password Support feature and requires MySQL version 8.0.14 or newer. See [MySQL Dual Password documentation](https://dev.mysql.com/doc/refman/8.0/en/password-management.html#dual-passwords) for more.
 * `tls_option` - (Optional) An TLS-Option for the `CREATE USER` or `ALTER USER` statement. The value is suffixed to `REQUIRE`. A value of 'SSL' will generate a `CREATE USER ... REQUIRE SSL` statement. See the [MYSQL `CREATE USER` documentation](https://dev.mysql.com/doc/refman/5.7/en/create-user.html) for more. Ignored if MySQL version is under 5.7.0.
 
 [ref-auth-plugins]: https://dev.mysql.com/doc/refman/5.7/en/authentication-plugins.html


### PR DESCRIPTION
Hello :wave:, this PR introduce the possibility of retaining the old password when the password change as described in https://github.com/petoju/terraform-provider-mysql/issues/17.

I would like to add a test but I'm not very fluent in Go and unless I'm mistaken there are currently no test that check if the user password works from which I could copy/inspire. Any feedback or advice is very welcome :pray: 