### PR TITLE
fix: procedure formatting

### DIFF
--- a/mysql/resource_role_test.go
+++ b/mysql/resource_role_test.go
@@ -111,3 +111,64 @@ resource "mysql_role" "test" {
 }
 `, roleName)
 }
+
+func TestAccGrantOnProcedure(t *testing.T) {
+	procedureName := "test_procedure"
+	userName := "test_user"
+	hostName := "%"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGrantCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGrantConfigProcedure(procedureName, userName, hostName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckProcedureGrant("mysql_grant.test_procedure", userName, hostName, procedureName, true),
+					resource.TestCheckResourceAttr("mysql_grant.test_procedure", "user", userName),
+					resource.TestCheckResourceAttr("mysql_grant.test_procedure", "host", hostName),
+					resource.TestCheckResourceAttr("mysql_grant.test_procedure", "database", fmt.Sprintf("PROCEDURE %s", procedureName)),
+					resource.TestCheckResourceAttr("mysql_grant.test_procedure", "table", ""), // Ensure table attribute is empty
+				),
+			},
+		},
+	})
+}
+
+func testAccGrantConfigProcedure(procedureName, userName, hostName string) string {
+	return fmt.Sprintf(`
+resource "mysql_grant" "test_procedure" {
+    user       = "%s"
+    host       = "%s"
+    privileges = ["EXECUTE"]
+    database   = "PROCEDURE %s"
+}
+`, userName, hostName, procedureName)
+}
+
+func testAccCheckProcedureGrant(resourceName, userName, hostName, procedureName string, expected bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Obtain the database connection from the Terraform provider
+		ctx := context.Background()
+		db, err := connectToMySQL(ctx, testAccProvider.Meta().(*MySQLConfiguration))
+		if err != nil {
+			return err
+		}
+
+		// Query the database to check if the grant exists
+		var exists bool
+		query := fmt.Sprintf("SELECT EXISTS(SELECT * FROM information_schema.routine_privileges WHERE grantee = '%s@%s' AND routine_name = '%s' AND privilege_type = 'EXECUTE')", userName, hostName, procedureName)
+		err = db.QueryRow(query).Scan(&exists)
+		if err != nil {
+			return err
+		}
+
+		// Compare the result with the expected outcome
+		if exists != expected {
+			return fmt.Errorf("Grant for procedure %s does not match expected state: %v", procedureName, expected)
+		}
+
+		return nil
+	}
+}


### PR DESCRIPTION
## What does this PR do?
- This logic currently mishandles role grants for procedures. Procedures don't belong to a table. However, the logic tries to suffix a wildcard table onto the procedure. 
- This PR adds conditional logic to handle this case. it also adds a test to cover this case.