### PR TITLE
Enable automatic IAM database authN for Cloud SQL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.31.0
 	github.com/tidwall/gjson v1.17.0
 	golang.org/x/net v0.20.0
+	golang.org/x/oauth2 v0.16.0
 	google.golang.org/api v0.157.0
 )
 
@@ -76,7 +77,6 @@ require (
 	go.opentelemetry.io/otel/trace v1.22.0 // indirect
 	golang.org/x/crypto v0.18.0 // indirect
 	golang.org/x/mod v0.14.0 // indirect
-	golang.org/x/oauth2 v0.16.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -184,10 +184,10 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		endpoint = strings.ReplaceAll(endpoint, "cloudsql://", "")
 		var err error
 		if iam_auth { // Access token will be in the password field
-			token_opetion := cloudsqlconn.WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{
+			token := oauth2.StaticTokenSource(&oauth2.Token{
 				AccessToken: password,
-			}))
-			_, err = cloudsql.RegisterDriver("cloudsql", token_opetion, cloudsqlconn.WithIAMAuthN())
+			})
+			_, err = cloudsql.RegisterDriver("cloudsql", cloudsqlconn.WithIAMAuthNTokenSources(token, token))
 		} else {
 			_, err = cloudsql.RegisterDriver("cloudsql")
 		}

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"golang.org/x/net/proxy"
+	"golang.org/x/oauth2"
 
 	cloudsqlconn "cloud.google.com/go/cloudsqlconn"
 	cloudsql "cloud.google.com/go/cloudsqlconn/mysql/mysql"
@@ -182,8 +183,11 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		proto = "cloudsql"
 		endpoint = strings.ReplaceAll(endpoint, "cloudsql://", "")
 		var err error
-		if iam_auth {
-			_, err = cloudsql.RegisterDriver("cloudsql", cloudsqlconn.WithIAMAuthN())
+		if iam_auth { // Access token will be in the password field
+			token_opetion := cloudsqlconn.WithTokenSource(oauth2.StaticTokenSource(&oauth2.Token{
+				AccessToken: password,
+			}))
+			_, err = cloudsql.RegisterDriver("cloudsql", token_opetion, cloudsqlconn.WithIAMAuthN())
 		} else {
 			_, err = cloudsql.RegisterDriver("cloudsql")
 		}

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -184,10 +184,15 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		endpoint = strings.ReplaceAll(endpoint, "cloudsql://", "")
 		var err error
 		if iam_auth { // Access token will be in the password field
+
+			var opts []cloudsqlconn.Option
+
 			token := oauth2.StaticTokenSource(&oauth2.Token{
 				AccessToken: password,
 			})
-			_, err = cloudsql.RegisterDriver("cloudsql", cloudsqlconn.WithIAMAuthNTokenSources(token, token))
+			opts = append(opts, cloudsqlconn.WithIAMAuthN())
+			opts = append(opts, cloudsqlconn.WithIAMAuthNTokenSources(token, token))
+			_, err = cloudsql.RegisterDriver("cloudsql", opts...)
 		} else {
 			_, err = cloudsql.RegisterDriver("cloudsql")
 		}

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -120,3 +120,4 @@ The following arguments are supported:
 * `max_open_conns` - (Optional) Sets the maximum number of open connections to the database. If n <= 0, then there is no limit on the number of open connections.
 * `conn_params` - (Optional) Sets extra mysql connection parameters (ODBC parameters). Most useful for session variables such as `default_storage_engine`, `foreign_key_checks` or `sql_log_bin`.
 * `authentication_plugin` - (Optional) Sets the authentication plugin, it can be one of the following: `native` or `cleartext`. Defaults to `native`.
+* `iam_database_authentication` - (Optional) For Cloud SQL databases, it enabled the use of IAM authentication. Make sure to delcare the `password` field with a temporary OAuth2 token of the user that will connect to the MySQL server.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -120,4 +120,4 @@ The following arguments are supported:
 * `max_open_conns` - (Optional) Sets the maximum number of open connections to the database. If n <= 0, then there is no limit on the number of open connections.
 * `conn_params` - (Optional) Sets extra mysql connection parameters (ODBC parameters). Most useful for session variables such as `default_storage_engine`, `foreign_key_checks` or `sql_log_bin`.
 * `authentication_plugin` - (Optional) Sets the authentication plugin, it can be one of the following: `native` or `cleartext`. Defaults to `native`.
-* `iam_database_authentication` - (Optional) For Cloud SQL databases, it enabled the use of IAM authentication. Make sure to delcare the `password` field with a temporary OAuth2 token of the user that will connect to the MySQL server.
+* `iam_database_authentication` - (Optional) For Cloud SQL databases, it enabled the use of IAM authentication. Make sure to declare the `password` field with a temporary OAuth2 token of the user that will connect to the MySQL server.


### PR DESCRIPTION
* Add `iam_database_authentication` option in the provider to switch on/off IAM authN
* If `iam_database_authentication`, the `password` field will be a temporary access token. The implementation follows the example made in [the documentation](https://cloud.google.com/sql/docs/mysql/iam-logins#log-in-with-automatic).