### PR TITLE
Fix "make test" and "make website"

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -12,10 +12,7 @@ default: build
 build: fmtcheck
 	go install
 
-test: fmtcheck
-	go test -i $(TEST) || exit 1
-	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=60s -parallel=4
+test: acceptance
 
 bin/terraform:
 	mkdir -p "$(CURDIR)/bin"
@@ -115,6 +112,8 @@ ifeq (,$(wildcard $(GOPATH)/src/$(WEBSITE_REPO)))
 	echo "$(WEBSITE_REPO) not found in your GOPATH (necessary for layouts and assets), get-ting..."
 	git clone https://$(WEBSITE_REPO) $(GOPATH)/src/$(WEBSITE_REPO)
 endif
+	( cd "$(GOPATH)/src/$(WEBSITE_REPO)" && git checkout 6d41be434cf85392bc9de773d8a5a8d571a195ad )
+
 	@$(MAKE) -C $(GOPATH)/src/$(WEBSITE_REPO) website-provider PROVIDER_PATH=$(shell pwd) PROVIDER_NAME=$(PKG_NAME)
 
 .PHONY: build test testacc vet fmt fmtcheck errcheck vendor-status test-compile website website-test


### PR DESCRIPTION
Note that these are only temporary fixes - we should migrate website to MDX and people generally shouldn't use "make test" or we should protect it somehow.

This is to make development easier.