### PR TITLE
Fix grant import

### DIFF
--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -732,8 +732,7 @@ func setDataFromGrant(grant MySQLGrant, d *schema.ResourceData) *schema.Resource
 		database := procedureGrant.Database
 		id := produceGrantId(database, userOrRole.Name, userOrRole.Host)
 		d.SetId(id)
-		d.Set("database", fmt.Sprintf("procedure %s.%s", database, procedureGrant.CallableName))
-		d.Set("callable_name", procedureGrant.CallableName)
+		d.Set("database", fmt.Sprintf("PROCEDURE %s.%s", database, procedureGrant.CallableName))
 	} else if roleGrant, ok := grant.(*RoleGrant); ok {
 		d.Set("grant", grant.GrantOption())
 		d.Set("roles", roleGrant.Roles)

--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -698,7 +698,7 @@ func ImportGrant(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 }
 
 func produceGrantId(database string, username string, host string) string {
-	if strings.Compare(database, "*") != 0 && !strings.HasSuffix(database, "`") {
+	if database != "*" && !strings.HasSuffix(database, "`") {
 		reProcedure := regexp.MustCompile(`(?i)^(function|procedure) (.*)$`)
 		if reProcedure.MatchString(database) {
 			// This is only a hack - user can specify function / procedure as database.

--- a/mysql/resource_grant_test.go
+++ b/mysql/resource_grant_test.go
@@ -3,14 +3,15 @@ package mysql
 import (
 	"context"
 	"fmt"
-	_ "github.com/go-sql-driver/mysql"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"log"
 	"math/rand"
 	"regexp"
 	"strings"
 	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccGrant(t *testing.T) {
@@ -423,11 +424,11 @@ func testAccPrivilege(rn string, privilege string, expectExists bool, expectGran
 			return err
 		}
 
-		id := strings.Split(rs.Primary.ID, ":")
+		id := strings.Split(rs.Primary.ID, "@")
 
 		var userOrRole UserOrRole
-		if strings.Contains(id[0], "@") {
-			parts := strings.Split(id[0], "@")
+		if strings.Contains(id[1], ":") {
+			parts := strings.Split(id[1], ":")
 			userOrRole = UserOrRole{
 				Name: parts[0],
 				Host: parts[1],
@@ -887,21 +888,6 @@ func TestAccGrantOnProcedure(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					prepareProcedure(dbName, procedureName),
 				),
-			},
-			{
-				Config: testAccGrantConfigProcedureWithTable(procedureName, dbName, hostName),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckProcedureGrant("mysql_grant.test_procedure", userName, hostName, procedureName, true),
-					resource.TestCheckResourceAttr("mysql_grant.test_procedure", "user", userName),
-					resource.TestCheckResourceAttr("mysql_grant.test_procedure", "host", hostName),
-					// Note: The database and table name do not change. This is to preserve legacy functionality.
-					resource.TestCheckResourceAttr("mysql_grant.test_procedure", "database", fmt.Sprintf("PROCEDURE %s", dbName)),
-					resource.TestCheckResourceAttr("mysql_grant.test_procedure", "table", procedureName),
-				),
-			},
-			{
-				// Remove the grant
-				Config: testAccGrantConfigNoGrant(dbName),
 			},
 			{
 				Config: testAccGrantConfigProcedureWithDatabase(procedureName, dbName, hostName),

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -131,7 +131,7 @@ The following arguments are supported:
 * `password` - (Optional) Password for the given user, if that user has a password, can also be sourced from the `MYSQL_PASSWORD` environment variable.
 * `proxy` - (Optional) Proxy socks url, can also be sourced from `ALL_PROXY` or `all_proxy` environment variables.
 * `tls` - (Optional) The TLS configuration. One of `false`, `true`, or `skip-verify`. Defaults to `false`. Can also be sourced from the `MYSQL_TLS_CONFIG` environment variable.
-* `custom_tls` - (Optional) Sets custom tls options for the connection. Documentation for encrypted connections can be found [here](https://dev.mysql.com/doc/refman/8.0/en/using-encrypted-connections.html). Consider setting shorter `connect_retry_timeout_sec` for debugging, as the default is 10 minutes .This is a block containing an optional `config_key`, which value is discarded but might be useful when troubleshooting, and the following required arguments:
+* `custom_tls` - (Optional) Sets custom tls options for the connection. Documentation for encrypted connections can be found [here](https://dev.mysql.com/doc/refman/8.0/en/using-encrypted-connections.html). Consider setting shorter `connect_retry_timeout_sec` for debugging, as the default is 10 minutes. This is a block containing an optional `config_key`, which value is discarded but might be useful when troubleshooting, and the following required arguments:
   * `ca_cert`
   * `client_cert`
   * `client_key`


### PR DESCRIPTION
This fixes the issue described in
https://github.com/petoju/terraform-provider-mysql/issues/112 where it's
not possible to import some grants. In short, it:
- Adds type for parsing the grant resource from data,
  `desiredProcedureGrant`, separating it from `desiredGrant`, which now
  becomes `desiredTableGrant`. This is used when trying to find a
  conflict and can probably be made a bit more generic, but it's likely
  outside the scope of this change (see below)
- Refactors the old `formatDatabaseName` into `produceGrantId` which, as
  the name says, produced the grant id that is going to be used by the
  provider.
- Sets some additional required fields for importing the grants, the
  most important one being the `id` which was missing and causing the
  errors that were seen in the issue above.

It also fixes a typo in the docs that I introduced earlier.

There are a few things worth noting:
- Role grants are not covered. Unfortunately, I don't currently have a use case for
  that, so there's no good way of testing it properly.
- As mentioned before, there are parts of the code that could be
  refactored to be more generic. That being said, it would also require
  implementing the fixes for role grants to write it in such a
  way that it would be properly generic.