### PR TITLE
Add Cloud SQL instances private ip option

### DIFF
--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -183,6 +183,11 @@ func Provider() *schema.Provider {
 				Optional: true,
 				Default:  false,
 			},
+			"private_ip": {
+                                Type:     schema.TypeBool,
+                                Optional: true,
+                                Default:  false,
+                        },
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -213,6 +218,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	var allowNativePasswords = authPlugin == nativePasswords
 	var password = d.Get("password").(string)
 	var iam_auth = d.Get("iam_database_authentication").(bool)
+	var private_ip = d.Get("private_ip").(bool)
 	var tlsConfig = d.Get("tls").(string)
 	var tlsConfigStruct *tls.Config
 
@@ -272,7 +278,12 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 			opts = append(opts, cloudsqlconn.WithIAMAuthNTokenSources(token, token))
 			_, err = cloudsql.RegisterDriver("cloudsql", opts...)
 		} else {
-			_, err = cloudsql.RegisterDriver("cloudsql")
+			var endpointParams []cloudsqlconn.DialOption
+			if private_ip {
+				endpointParams = append(endpointParams, cloudsqlconn.WithPrivateIP())
+			}
+
+			_, err = cloudsql.RegisterDriver("cloudsql", cloudsqlconn.WithDefaultDialOptions(endpointParams...))
 		}
 		if err != nil {
 			return nil, diag.Errorf("failed to register driver %v", err)

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -184,10 +184,10 @@ func Provider() *schema.Provider {
 				Default:  false,
 			},
 			"private_ip": {
-                                Type:     schema.TypeBool,
-                                Optional: true,
-                                Default:  false,
-                        },
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -153,4 +153,4 @@ The following arguments are supported:
 * `conn_params` - (Optional) Sets extra mysql connection parameters (ODBC parameters). Most useful for session variables such as `default_storage_engine`, `foreign_key_checks` or `sql_log_bin`.
 * `authentication_plugin` - (Optional) Sets the authentication plugin, it can be one of the following: `native` or `cleartext`. Defaults to `native`.
 * `iam_database_authentication` - (Optional) For Cloud SQL databases, it enabled the use of IAM authentication. Make sure to declare the `password` field with a temporary OAuth2 token of the user that will connect to the MySQL server.
-* `private_ip` - (Optional) Whether to use a connection to an instance with a private ip. Defaults to `false`.
+* `private_ip` - (Optional) Whether to use a connection to an instance with a private ip. Defaults to `false`. This argument only applies to CloudSQL and is ignored elsewhere.

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -94,6 +94,18 @@ provider "mysql" {
 }
 ```
 
+For a connection to an instance with no public IP add the `private_ip` option to the provider configuration.
+
+```hcl
+# Configure the MySQL provider for CloudSQL Mysql
+provider "mysql" {
+  endpoint = "cloudsql://project:region:instance"
+  username = "app-user"
+  password = "app-password"
+  private_ip = true
+}
+```
+
 See also: [Authentication at Google](https://cloud.google.com/docs/authentication#service-accounts).
 
 ### Azure MySQL server with AzureAD auth enabled connection
@@ -141,3 +153,4 @@ The following arguments are supported:
 * `conn_params` - (Optional) Sets extra mysql connection parameters (ODBC parameters). Most useful for session variables such as `default_storage_engine`, `foreign_key_checks` or `sql_log_bin`.
 * `authentication_plugin` - (Optional) Sets the authentication plugin, it can be one of the following: `native` or `cleartext`. Defaults to `native`.
 * `iam_database_authentication` - (Optional) For Cloud SQL databases, it enabled the use of IAM authentication. Make sure to declare the `password` field with a temporary OAuth2 token of the user that will connect to the MySQL server.
+* `private_ip` - (Optional) Whether to use a connection to an instance with a private ip. Defaults to `false`.


### PR DESCRIPTION
 GCP Cloud SQL - Add support for PRIVATE_IP #117 

Add new bool option private_ip to connect to gcp cloud sql instance with private ip without locally running cloud-sql-proxy