### PR TITLE
Add support for all Azure Clouds

### DIFF
--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -312,7 +312,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		} else if os.Getenv("ARM_ENVIRONMENT") == "german" {
 			azScope = "https://ossrdbms-aad.database.chinacloudapi.de"
 		} else if os.Getenv("ARM_ENVIRONMENT") == "usgovernment" {
-			azScope = "https://ossrdbms-aad.database.usgovcloudapi.net
+			azScope = "https://ossrdbms-aad.database.usgovcloudapi.net"
 		}
 
 		if err != nil {

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -309,6 +309,10 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		azScope := "https://ossrdbms-aad.database.windows.net"
 		if os.Getenv("ARM_ENVIRONMENT") == "china" {
 			azScope = "https://ossrdbms-aad.database.chinacloudapi.cn"
+		} else if os.Getenv("ARM_ENVIRONMENT") == "german" {
+			azScope = "https://ossrdbms-aad.database.chinacloudapi.de"
+		} else if os.Getenv("ARM_ENVIRONMENT") == "usgovernment" {
+			azScope = "https://ossrdbms-aad.database.usgovcloudapi.net
 		}
 
 		if err != nil {

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -306,6 +306,10 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		allowClearTextPasswords = true
 		azCredential, err := azidentity.NewDefaultAzureCredential(nil)
 		endpoint = strings.ReplaceAll(endpoint, "azure://", "")
+		azScope := "https://ossrdbms-aad.database.windows.net"
+		if os.Getenv("ARM_ENVIRONMENT") == "china" {
+			azScope = "https://ossrdbms-aad.database.chinacloudapi.cn"
+		}
 
 		if err != nil {
 			return nil, diag.Errorf("failed to create Azure credential %v", err)
@@ -313,7 +317,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 		azToken, err := azCredential.GetToken(
 			ctx,
-			policy.TokenRequestOptions{Scopes: []string{"https://ossrdbms-aad.database.windows.net/.default"}},
+			policy.TokenRequestOptions{Scopes: []string{azScope + "/.default"}},
 		)
 
 		if err != nil {


### PR DESCRIPTION
To support aad authentication in other Azure Clouds, the scope needs to be updated for the the destination Azure Cloud.

To support detection of which cloud is being used, the code references the Terraform azurerm provider environment variable [ARM_ENVIRONMENT](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs#environment).

It is likely this URL could be grabbed from the Azure go SDK since it is available via the az CLI.

```
az cloud show --name AzureCloud |grep ossrdbms
    "ossrdbmsResourceId": "https://ossrdbms-aad.database.windows.net",
az cloud show --name AzureChinaCloud |grep ossrdbms
    "ossrdbmsResourceId": "https://ossrdbms-aad.database.chinacloudapi.cn",
az cloud show --name AzureUSGovernment |grep ossrdbms
    "ossrdbmsResourceId": "https://ossrdbms-aad.database.usgovcloudapi.net"
az cloud show --name AzureGermanCloud |grep ossrdbms
    "ossrdbmsResourceId": "https://ossrdbms-aad.database.cloudapi.de"
```

I have been able to test this successfully using AzureCloud and AzureChinaCLoud.

Without this fix when running against AzureChinaCloud terraform would generate the following error when it tries to refresh the resource.

```
│ Error: failed to get token from Azure AD DefaultAzureCredential: failed to acquire a token.
│ Attempted credentials:
│       EnvironmentCredential: missing environment variable AZURE_TENANT_ID
│       WorkloadIdentityCredential: no client ID specified. Check pod configuration or set ClientID in the options
│       ManagedIdentityCredential: managed identity timed out. See https://aka.ms/azsdk/go/identity/troubleshoot#dac for more information
│       AzureCLICredential: ERROR: AADSTS500011: The resource principal named https://ossrdbms-aad.database.windows.net/ was not found in the tenant named PVUECN. This can happen if the application has not been installed by the administrator of the tenant or consented to by any user in the tenant. You might have sent your authentication request to the wrong tenant. Trace ID: 982556b8-904c-402e-b93e-935933478800 Correlation ID: ccd73ba7-a547-4a08-b614-8fddd1f41fce Timestamp: 2024-03-26 19:35:16Z
│ Interactive authentication is needed. Please run:
│ az login --scope https://ossrdbms-aad.database.windows.net/.default
│
│       AzureDeveloperCLICredential: Azure Developer CLI not found on path
│
│   with provider["registry.terraform.io/petoju/mysql"].aad,
```