### PR TITLE
Add default roles resource

### DIFF
--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -204,6 +204,7 @@ func Provider() *schema.Provider {
 			"mysql_user":            resourceUser(),
 			"mysql_ti_config":       resourceTiConfigVariable(),
 			"mysql_rds_config":      resourceRDSConfig(),
+			"mysql_default_roles":   resourceDefaultRoles(),
 		},
 
 		ConfigureContextFunc: providerConfigure,

--- a/mysql/resource_default_roles.go
+++ b/mysql/resource_default_roles.go
@@ -1,0 +1,211 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/go-version"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceDefaultRoles() *schema.Resource {
+	return &schema.Resource{
+		CreateContext: CreateDefaultRoles,
+		UpdateContext: UpdateDefaultRoles,
+		ReadContext:   ReadDefaultRoles,
+		DeleteContext: DeleteDefaultRoles,
+		Importer: &schema.ResourceImporter{
+			StateContext: ImportDefaultRoles,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"user": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"host": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "localhost",
+			},
+
+			"roles": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Set: schema.HashString,
+			},
+		},
+	}
+}
+
+func checkDefaultRolesSupport(ctx context.Context, meta interface{}) error {
+	ver, _ := version.NewVersion("8.0.0")
+	if getVersionFromMeta(ctx, meta).LessThan(ver) {
+		return errors.New("MySQL version must be at least 8.0.0")
+	}
+	return nil
+}
+
+func alterUserDefaultRoles(ctx context.Context, db *sql.DB, user, host string, roles []string) error {
+	var stmtSQL string
+
+	stmtSQL = fmt.Sprintf("ALTER USER '%s'@'%s' DEFAULT ROLE ", user, host)
+
+	if len(roles) > 0 {
+		stmtSQL += fmt.Sprintf("'%s'", strings.Join(roles, "', '"))
+	} else {
+		stmtSQL += "NONE"
+	}
+
+	log.Println("Executing statement:", stmtSQL)
+	_, err := db.ExecContext(ctx, stmtSQL)
+	if err != nil {
+		return fmt.Errorf("failed executing SQL: %v", err)
+	}
+
+	return nil
+}
+
+func getRolesFromData(d *schema.ResourceData) []string {
+	defaultRoles := d.Get("roles").(*schema.Set).List()
+	roles := make([]string, len(defaultRoles))
+	for i, role := range defaultRoles {
+		roles[i] = role.(string)
+	}
+
+	return roles
+}
+
+func CreateDefaultRoles(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	db, err := getDatabaseFromMeta(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if err := checkDefaultRolesSupport(ctx, meta); err != nil {
+		return diag.Errorf("cannot use default roles: %v", err)
+	}
+
+	user := d.Get("user").(string)
+	host := d.Get("host").(string)
+	roles := getRolesFromData(d)
+
+	if err := alterUserDefaultRoles(ctx, db, user, host, roles); err != nil {
+		return diag.Errorf("failed to create user default roles: %v", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s@%s", user, host))
+
+	return nil
+}
+
+func UpdateDefaultRoles(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	db, err := getDatabaseFromMeta(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if err := checkDefaultRolesSupport(ctx, meta); err != nil {
+		return diag.Errorf("cannot use default roles: %v", err)
+	}
+
+	if d.HasChange("roles") {
+		user := d.Get("user").(string)
+		host := d.Get("host").(string)
+		roles := getRolesFromData(d)
+
+		if err := alterUserDefaultRoles(ctx, db, user, host, roles); err != nil {
+			return diag.Errorf("failed to update user default roles: %v", err)
+		}
+	}
+
+	return nil
+}
+
+func ReadDefaultRoles(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	db, err := getDatabaseFromMeta(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if err := checkDefaultRolesSupport(ctx, meta); err != nil {
+		return diag.Errorf("cannot use default roles: %v", err)
+	}
+
+	stmtSQL := "SELECT default_role_user FROM mysql.default_roles WHERE user = ? AND host = ?"
+
+	log.Println("Executing statement:", stmtSQL)
+
+	rows, err := db.QueryContext(ctx, stmtSQL, d.Get("user").(string), d.Get("host").(string))
+	if err != nil {
+		return diag.Errorf("failed to read user default roles from DB: %v", err)
+	}
+	defer rows.Close()
+
+	var defaultRoles = make([]string, 0)
+	for rows.Next() {
+		var role string
+		err := rows.Scan(&role)
+		if err != nil {
+			return diag.Errorf("failed scanning default roles: %v", err)
+		}
+		defaultRoles = append(defaultRoles, role)
+	}
+
+	if rows.Err() != nil {
+		return diag.Errorf("failed getting rows: %v", rows.Err())
+	}
+
+	d.Set("roles", defaultRoles)
+
+	return nil
+}
+
+func DeleteDefaultRoles(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	db, err := getDatabaseFromMeta(ctx, meta)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	if err := checkDefaultRolesSupport(ctx, meta); err != nil {
+		return diag.Errorf("cannot use default roles: %v", err)
+	}
+
+	user := d.Get("user").(string)
+	host := d.Get("host").(string)
+
+	if err := alterUserDefaultRoles(ctx, db, user, host, []string{}); err != nil {
+		return diag.Errorf("failed to remove user default roles: %v", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func ImportDefaultRoles(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	userHost := strings.SplitN(d.Id(), "@", 2)
+
+	if len(userHost) != 2 {
+		return nil, fmt.Errorf("wrong ID format %s (expected USER@HOST)", d.Id())
+	}
+
+	d.Set("user", userHost[0])
+	d.Set("host", userHost[1])
+
+	var err error
+
+	readErr := ReadDefaultRoles(ctx, d, meta)
+	if readErr.HasError() {
+		err = fmt.Errorf("failed reading default roles: %v", err)
+	}
+
+	return []*schema.ResourceData{d}, err
+}

--- a/mysql/resource_default_roles_test.go
+++ b/mysql/resource_default_roles_test.go
@@ -83,7 +83,7 @@ func testAccDefaultRoles(rn string, roles ...string) resource.TestCheckFunc {
 		log.Println("Executing statement:", stmtSQL)
 		rows, err := db.Query(stmtSQL)
 		if err != nil {
-			return fmt.Errorf("error reading user default roles: %s", err)
+			return fmt.Errorf("error reading user default roles: %w", err)
 		}
 		defer rows.Close()
 
@@ -93,7 +93,7 @@ func testAccDefaultRoles(rn string, roles ...string) resource.TestCheckFunc {
 			var role string
 			err := rows.Scan(&role)
 			if err != nil {
-				return fmt.Errorf("error reading user default roles: %s", err)
+				return fmt.Errorf("error reading user default roles: %w", err)
 			}
 			dbRoles = append(dbRoles, role)
 		}
@@ -133,7 +133,7 @@ func testAccDefaultRolesCheckDestroy(s *terraform.State) error {
 		var count int
 		err := db.QueryRow(stmtSQL).Scan(&count)
 		if err != nil {
-			return fmt.Errorf("error issuing query: %s", err)
+			return fmt.Errorf("error issuing query: %w", err)
 		}
 		if count > 0 {
 			return fmt.Errorf("default roles still exist after destroy")

--- a/mysql/resource_default_roles_test.go
+++ b/mysql/resource_default_roles_test.go
@@ -1,0 +1,208 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDefaultRoles_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckSkipNotMySQL8(t)
+			testAccPreCheckSkipMariaDB(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccDefaultRolesCheckDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDefaultRoles_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDefaultRoles("mysql_default_roles.test", "role1"),
+					resource.TestCheckResourceAttr("mysql_default_roles.test", "roles.#", "1"),
+					resource.TestCheckResourceAttr("mysql_default_roles.test", "roles.0", "role1"),
+				),
+			},
+			{
+				Config: testAccDefaultRoles_multiple,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDefaultRoles("mysql_default_roles.test", "role1", "role2"),
+					resource.TestCheckResourceAttr("mysql_default_roles.test", "roles.#", "2"),
+					resource.TestCheckResourceAttr("mysql_default_roles.test", "roles.0", "role1"),
+					resource.TestCheckResourceAttr("mysql_default_roles.test", "roles.1", "role2"),
+				),
+			},
+			{
+				Config: testAccDefaultRoles_none,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDefaultRoles("mysql_default_roles.test"),
+					resource.TestCheckResourceAttr("mysql_default_roles.test", "roles.#", "0"),
+				),
+			},
+			{
+				Config:            testAccDefaultRoles_basic,
+				ResourceName:      "mysql_default_roles.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("%v@%v", "jdoe", "%"),
+			},
+			{
+				Config:            testAccDefaultRoles_multiple,
+				ResourceName:      "mysql_default_roles.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     fmt.Sprintf("%v@%v", "jdoe", "%"),
+			},
+		},
+	})
+}
+
+func testAccDefaultRoles(rn string, roles ...string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[rn]
+		if !ok {
+			return fmt.Errorf("resource not found: %s", rn)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("default roles id not set")
+		}
+
+		ctx := context.Background()
+		db, err := connectToMySQL(ctx, testAccProvider.Meta().(*MySQLConfiguration))
+		if err != nil {
+			return err
+		}
+
+		stmtSQL := fmt.Sprintf("SELECT default_role_user from mysql.default_roles where CONCAT(user, '@', host) = '%s'", rs.Primary.ID)
+		log.Println("Executing statement:", stmtSQL)
+		rows, err := db.Query(stmtSQL)
+		if err != nil {
+			return fmt.Errorf("error reading user default roles: %s", err)
+		}
+		defer rows.Close()
+
+		dbRoles := make([]string, 0)
+
+		for rows.Next() {
+			var role string
+			err := rows.Scan(&role)
+			if err != nil {
+				return fmt.Errorf("error reading user default roles: %s", err)
+			}
+			dbRoles = append(dbRoles, role)
+		}
+
+		if len(dbRoles) != len(roles) {
+			return fmt.Errorf("expected %d rows reading user default roles but got %d", len(roles), len(dbRoles))
+		}
+
+		exists := make(map[string]bool)
+		for _, role := range dbRoles {
+			exists[role] = true
+		}
+		for _, role := range roles {
+			if !exists[role] {
+				return fmt.Errorf("expected role %s in user default roles but it was not found", role)
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccDefaultRolesCheckDestroy(s *terraform.State) error {
+	ctx := context.Background()
+	db, err := connectToMySQL(ctx, testAccProvider.Meta().(*MySQLConfiguration))
+	if err != nil {
+		return err
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "mysql_default_roles" {
+			continue
+		}
+
+		stmtSQL := fmt.Sprintf("SELECT count(*) FROM mysql.default_roles WHERE CONCAT(user, '@', host) = '%s'", rs.Primary.ID)
+		log.Println("Executing statement:", stmtSQL)
+		var count int
+		err := db.QueryRow(stmtSQL).Scan(&count)
+		if err != nil {
+			return fmt.Errorf("error issuing query: %s", err)
+		}
+		if count > 0 {
+			return fmt.Errorf("default roles still exist after destroy")
+		}
+	}
+	return nil
+}
+
+const testAccDefaultRoles_basic = `
+resource "mysql_role" "role1" {
+	name = "role1"
+}
+
+resource "mysql_user" "test" {
+	user = "jdoe"
+	host = "%"
+}
+
+resource "mysql_grant" "test" {
+	user     = mysql_user.test.user
+	host     = mysql_user.test.host
+	database = ""
+	roles    = [mysql_role.role1.name]
+}
+
+resource "mysql_default_roles" "test" {
+	user = mysql_user.test.user
+	host = mysql_user.test.host
+	roles = mysql_grant.test.roles
+}
+`
+
+const testAccDefaultRoles_multiple = `
+resource "mysql_role" "role1" {
+	name = "role1"
+}
+
+resource "mysql_role" "role2" {
+	name = "role2"
+}
+
+resource "mysql_user" "test" {
+	user = "jdoe"
+	host = "%"
+}
+
+resource "mysql_grant" "test" {
+	user     = mysql_user.test.user
+	host     = mysql_user.test.host
+	database = ""
+	roles    = [mysql_role.role1.name, mysql_role.role2.name]
+}
+
+resource "mysql_default_roles" "test" {
+	user = mysql_user.test.user
+	host = mysql_user.test.host
+	roles = mysql_grant.test.roles
+}
+`
+
+const testAccDefaultRoles_none = `
+resource "mysql_user" "test" {
+	user = "jdoe"
+	host = "%"
+}
+
+resource "mysql_default_roles" "test" {
+	user = mysql_user.test.user
+	host = mysql_user.test.host
+	roles = []
+}
+`

--- a/website/docs/r/default_roles.html.markdown
+++ b/website/docs/r/default_roles.html.markdown
@@ -1,0 +1,66 @@
+---
+layout: "mysql"
+page_title: "MySQL: mysql_default_roles"
+sidebar_current: "docs-mysql-default-roles"
+description: |-
+  Creates and manages a user's default roles on a MySQL server.
+---
+
+# mysql\_default_roles
+
+The ``mysql_default_roles`` resource creates and manages a user's default roles on a MySQL server.
+
+~> **Note:** This resource is available on MySQL version 8.0.0 and later.
+
+## Example Usage
+
+```hcl
+resource "mysql_role" "readonly" {
+  name = "readonly"
+}
+
+resource "mysql_user" "jdoe" {
+  user = "jdoe"
+  host = "%"
+}
+
+resource "mysql_grant" "jdoe" {
+  user     = mysql_user.jdoe.user
+  host     = mysql_user.jdoe.host
+  database = ""
+  roles    = [mysql_role.readonly.name]
+}
+
+resource "mysql_default_roles" "jdoe" {
+  user  = mysql_user.jdoe.user
+  host  = mysql_user.jdoe.host
+  roles = mysql_grant.jdoe.roles
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `user` - (Required) The name of the user.
+* `host` - (Optional) The source host of the user. Defaults to "localhost".
+* `roles` - (Optional) A list of default roles to assign to the user. By default no roles are assigned.
+
+~> **Note:** Creating a new default roles resource on an existing user will **overwrite** the user's existing default roles. Likewise, destryoing a default roles resource will **remove** the user's default roles, equivalent to running `ALTER USER ... DEFAULT ROLE NONE`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The id of the user default roles created, composed as "username@host".
+* `user` - The name of the user.
+* `host` - The host where the user was created.
+* `roles` - The default roles assigned to the user.
+
+## Import
+
+User default roles can be imported using user and host.
+
+```shell
+terraform import mysql_default_roles.example user@host
+```


### PR DESCRIPTION
Closes #38 and #119.

This PR adds a new resource called `mysql_default_roles` which allows you to set default rolest to users using the [ALTER USER ... DEFAULT ROLE](https://dev.mysql.com/doc/refman/8.0/en/alter-user.html) syntax.

**Example:**
```hcl
resource "mysql_role" "readonly" {
  name = "readonly"
}

resource "mysql_user" "jdoe" {
  user = "jdoe"
  host = "%"
}

resource "mysql_grant" "jdoe" {
  user     = mysql_user.jdoe.user
  host     = mysql_user.jdoe.host
  database = ""
  roles    = [mysql_role.readonly.name]
}

resource "mysql_default_roles" "jdoe" {
  user  = mysql_user.jdoe.user
  host  = mysql_user.jdoe.host
  roles = mysql_grant.jdoe.roles
}
```

I also added tests for this new resource and created a documentation page.

@petoju What do you think? Could you look over this PR? And thank you for keeping this provider alive!
