### PR TITLE
Fix crash when the user field is empty in the grant resource

### DIFF
--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -414,6 +414,9 @@ func parseResourceFromData(d *schema.ResourceData) (MySQLGrant, diag.Diagnostics
 	userAttr, userOk := d.GetOk("user")
 	hostAttr, hostOk := d.GetOk("host")
 	roleAttr, roleOk := d.GetOk("role")
+	if (userOk && userAttr.(string) == "") && (roleOk && roleAttr == "") {
+		return nil, diag.Errorf("User or role name must be specified")
+	}
 	if userOk && hostOk && userAttr.(string) != "" && hostAttr.(string) != "" {
 		userOrRole = UserOrRole{
 			Name: userAttr.(string),


### PR DESCRIPTION
Fixes #128

The provider segfaults because it references nil when the `user` field is empty.

This ensures either the role is specified or the user is specified.
