### PR TITLE
Change error strings, add details for grant parsing

### DIFF
--- a/mysql/resource_database.go
+++ b/mysql/resource_database.go
@@ -55,7 +55,7 @@ func CreateDatabase(ctx context.Context, d *schema.ResourceData, meta interface{
 	}
 
 	stmtSQL := databaseConfigSQL("CREATE", d)
-	log.Println("Executing statement:", stmtSQL)
+	log.Println("[DEBUG] Executing statement:", stmtSQL)
 
 	_, err = db.ExecContext(ctx, stmtSQL)
 	if err != nil {
@@ -74,7 +74,7 @@ func UpdateDatabase(ctx context.Context, d *schema.ResourceData, meta interface{
 	}
 
 	stmtSQL := databaseConfigSQL("ALTER", d)
-	log.Println("Executing statement:", stmtSQL)
+	log.Println("[DEBUG] Executing statement:", stmtSQL)
 
 	_, err = db.ExecContext(ctx, stmtSQL)
 	if err != nil {
@@ -98,7 +98,7 @@ func ReadDatabase(ctx context.Context, d *schema.ResourceData, meta interface{})
 	name := d.Id()
 	stmtSQL := "SHOW CREATE DATABASE " + quoteIdentifier(name)
 
-	log.Println("Executing query:", stmtSQL)
+	log.Println("[DEBUG] Executing query:", stmtSQL)
 	var createSQL, _database string
 	err = db.QueryRowContext(ctx, stmtSQL).Scan(&_database, &createSQL)
 	if err != nil {
@@ -160,7 +160,7 @@ func DeleteDatabase(ctx context.Context, d *schema.ResourceData, meta interface{
 
 	name := d.Id()
 	stmtSQL := "DROP DATABASE " + quoteIdentifier(name)
-	log.Println("Executing statement:", stmtSQL)
+	log.Println("[DEBUG] Executing statement:", stmtSQL)
 
 	_, err = db.ExecContext(ctx, stmtSQL)
 	if err != nil {

--- a/mysql/resource_default_roles.go
+++ b/mysql/resource_default_roles.go
@@ -68,7 +68,7 @@ func alterUserDefaultRoles(ctx context.Context, db *sql.DB, user, host string, r
 		stmtSQL += "NONE"
 	}
 
-	log.Println("Executing statement:", stmtSQL)
+	log.Println("[DEBUG] Executing statement:", stmtSQL)
 	_, err := db.ExecContext(ctx, stmtSQL)
 	if err != nil {
 		return fmt.Errorf("failed executing SQL: %w", err)
@@ -142,7 +142,7 @@ func ReadDefaultRoles(ctx context.Context, d *schema.ResourceData, meta interfac
 
 	stmtSQL := "SELECT default_role_user FROM mysql.default_roles WHERE user = ? AND host = ?"
 
-	log.Println("Executing statement:", stmtSQL)
+	log.Println("[DEBUG] Executing statement:", stmtSQL)
 
 	rows, err := db.QueryContext(ctx, stmtSQL, d.Get("user").(string), d.Get("host").(string))
 	if err != nil {

--- a/mysql/resource_default_roles_test.go
+++ b/mysql/resource_default_roles_test.go
@@ -80,7 +80,7 @@ func testAccDefaultRoles(rn string, roles ...string) resource.TestCheckFunc {
 		}
 
 		stmtSQL := fmt.Sprintf("SELECT default_role_user from mysql.default_roles where CONCAT(user, '@', host) = '%s'", rs.Primary.ID)
-		log.Println("Executing statement:", stmtSQL)
+		log.Println("[DEBUG] Executing statement:", stmtSQL)
 		rows, err := db.Query(stmtSQL)
 		if err != nil {
 			return fmt.Errorf("error reading user default roles: %w", err)
@@ -129,7 +129,7 @@ func testAccDefaultRolesCheckDestroy(s *terraform.State) error {
 		}
 
 		stmtSQL := fmt.Sprintf("SELECT count(*) FROM mysql.default_roles WHERE CONCAT(user, '@', host) = '%s'", rs.Primary.ID)
-		log.Println("Executing statement:", stmtSQL)
+		log.Println("[DEBUG] Executing statement:", stmtSQL)
 		var count int
 		err := db.QueryRow(stmtSQL).Scan(&count)
 		if err != nil {

--- a/mysql/resource_rds_config.go
+++ b/mysql/resource_rds_config.go
@@ -47,7 +47,7 @@ func CreateRDSConfig(ctx context.Context, d *schema.ResourceData, meta interface
 	}
 
 	for _, stmtSQL := range RDSConfigSQL(d) {
-		log.Println("Executing statement:", stmtSQL)
+		log.Println("[DEBUG] Executing statement:", stmtSQL)
 
 		_, err = db.ExecContext(ctx, stmtSQL)
 		if err != nil {
@@ -67,7 +67,7 @@ func UpdateRDSConfig(ctx context.Context, d *schema.ResourceData, meta interface
 	}
 
 	for _, stmtSQL := range RDSConfigSQL(d) {
-		log.Println("Executing statement:", stmtSQL)
+		log.Println("[DEBUG] Executing statement:", stmtSQL)
 
 		_, err = db.ExecContext(ctx, stmtSQL)
 		if err != nil {
@@ -86,7 +86,7 @@ func ReadRDSConfig(ctx context.Context, d *schema.ResourceData, meta interface{}
 
 	stmtSQL := "call mysql.rds_show_configuration"
 
-	log.Println("Executing query:", stmtSQL)
+	log.Println("[DEBUG] Executing query:", stmtSQL)
 	rows, err := db.QueryContext(ctx, stmtSQL)
 	if err != nil {
 		return diag.Errorf("Error reading RDS config from DB: %v", err)
@@ -138,7 +138,7 @@ func DeleteRDSConfig(ctx context.Context, d *schema.ResourceData, meta interface
 
 	stmtsSQL := []string{"call mysql.rds_set_configuration('binlog retention hours', NULL)", "call mysql.rds_set_configuration('target delay', 0)"}
 	for _, stmtSQL := range stmtsSQL {
-		log.Println("Executing statement:", stmtSQL)
+		log.Println("[DEBUG] Executing statement:", stmtSQL)
 
 		_, err = db.ExecContext(ctx, stmtSQL)
 		if err != nil {

--- a/mysql/resource_rds_config_test.go
+++ b/mysql/resource_rds_config_test.go
@@ -65,7 +65,7 @@ func testAccRDSCheckDestroy() resource.TestCheckFunc {
 
 		stmtSQL := "call mysql.rds_show_configuration"
 
-		log.Println("Executing query:", stmtSQL)
+		log.Println("[DEBUG] Executing query:", stmtSQL)
 		rows, err := db.QueryContext(ctx, stmtSQL)
 		if err != nil {
 			return err

--- a/mysql/resource_sql.go
+++ b/mysql/resource_sql.go
@@ -42,7 +42,7 @@ func CreateSql(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 	name := d.Get("name").(string)
 	createSql := d.Get("create_sql").(string)
 
-	log.Println("Executing SQL", createSql)
+	log.Println("[DEBUG] Executing SQL", createSql)
 
 	_, err = db.ExecContext(ctx, createSql)
 	if err != nil {
@@ -65,7 +65,7 @@ func DeleteSql(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 	}
 	deleteSql := d.Get("delete_sql").(string)
 
-	log.Println("Executing SQL:", deleteSql)
+	log.Println("[DEBUG] Executing SQL:", deleteSql)
 
 	_, err = db.ExecContext(ctx, deleteSql)
 	if err != nil {

--- a/mysql/resource_user.go
+++ b/mysql/resource_user.go
@@ -220,7 +220,7 @@ func CreateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		}
 	}
 
-	log.Println("Executing statement:", stmtSQL)
+	log.Println("[DEBUG] Executing statement:", stmtSQL)
 	_, err = db.ExecContext(ctx, stmtSQL)
 	if err != nil {
 		return diag.Errorf("failed executing SQL: %v", err)
@@ -230,7 +230,7 @@ func CreateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	d.SetId(user)
 
 	if updateStmtSql != "" {
-		log.Println("Executing statement:", updateStmtSql)
+		log.Println("[DEBUG] Executing statement:", updateStmtSql)
 		_, err = db.ExecContext(ctx, updateStmtSql)
 		if err != nil {
 			d.Set("tls_option", "")
@@ -279,7 +279,7 @@ func UpdateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 				authString,
 				d.Get("tls_option").(string))
 
-			log.Println("Executing query:", stmtSQL)
+			log.Println("[DEBUG] Executing query:", stmtSQL)
 			_, err := db.ExecContext(ctx, stmtSQL)
 			if err != nil {
 				return diag.Errorf("failed running query: %v", err)
@@ -310,7 +310,7 @@ func UpdateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 			return diag.Errorf("failed getting change password statement: %v", err)
 		}
 
-		log.Println("Executing query:", stmtSQL)
+		log.Println("[DEBUG] Executing query:", stmtSQL)
 		_, err = db.ExecContext(ctx, stmtSQL,
 			d.Get("user").(string),
 			d.Get("host").(string),
@@ -329,7 +329,7 @@ func UpdateUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 			d.Get("host").(string),
 			d.Get("tls_option").(string))
 
-		log.Println("Executing query:", stmtSQL)
+		log.Println("[DEBUG] Executing query:", stmtSQL)
 		_, err := db.ExecContext(ctx, stmtSQL)
 		if err != nil {
 			return diag.Errorf("failed setting require tls option: %v", err)
@@ -421,7 +421,7 @@ func ReadUser(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 		stmtSQL := fmt.Sprintf("SELECT USER FROM mysql.user WHERE USER='%s'",
 			d.Get("user").(string))
 
-		log.Println("Executing statement:", stmtSQL)
+		log.Println("[DEBUG] Executing statement:", stmtSQL)
 
 		rows, err := db.QueryContext(ctx, stmtSQL)
 		if err != nil {
@@ -448,7 +448,7 @@ func DeleteUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 
 	stmtSQL := fmt.Sprintf("DROP USER ?@?")
 
-	log.Println("Executing statement:", stmtSQL)
+	log.Println("[DEBUG] Executing statement:", stmtSQL)
 
 	_, err = db.ExecContext(ctx, stmtSQL,
 		d.Get("user").(string),

--- a/mysql/resource_user_password.go
+++ b/mysql/resource_user_password.go
@@ -141,7 +141,7 @@ func ReadUserPassword(ctx context.Context, d *schema.ResourceData, meta interfac
 	}
 
 	// User doesn't exist. Password is certainly wrong in mysql, destroy the resource.
-	log.Printf("User and host doesn't exist %s@%s", d.Get("user").(string), d.Get("host").(string))
+	log.Printf("[DEBUG] User and host doesn't exist %s@%s", d.Get("user").(string), d.Get("host").(string))
 	d.SetId("")
 	return nil
 }

--- a/mysql/resource_user_test.go
+++ b/mysql/resource_user_test.go
@@ -210,7 +210,7 @@ func testAccUserExists(rn string) resource.TestCheckFunc {
 		}
 
 		stmtSQL := fmt.Sprintf("SELECT count(*) from mysql.user where CONCAT(user, '@', host) = '%s'", rs.Primary.ID)
-		log.Println("Executing statement:", stmtSQL)
+		log.Println("[DEBUG] Executing statement:", stmtSQL)
 		var count int
 		err = db.QueryRow(stmtSQL).Scan(&count)
 		if err != nil {
@@ -242,7 +242,7 @@ func testAccUserAuthExists(rn string) resource.TestCheckFunc {
 		}
 
 		stmtSQL := fmt.Sprintf("SELECT count(*) from mysql.user where CONCAT(user, '@', host) = '%s' and plugin = 'mysql_no_login'", rs.Primary.ID)
-		log.Println("Executing statement:", stmtSQL)
+		log.Println("[DEBUG] Executing statement:", stmtSQL)
 		var count int
 		err = db.QueryRow(stmtSQL).Scan(&count)
 		if err != nil {
@@ -287,7 +287,7 @@ func testAccUserCheckDestroy(s *terraform.State) error {
 		}
 
 		stmtSQL := fmt.Sprintf("SELECT user from mysql.user where CONCAT(user, '@', host) = '%s'", rs.Primary.ID)
-		log.Println("Executing statement:", stmtSQL)
+		log.Println("[DEBUG] Executing statement:", stmtSQL)
 		rows, err := db.Query(stmtSQL)
 		if err != nil {
 			return fmt.Errorf("error issuing query: %s", err)


### PR DESCRIPTION
I added everywhere [DEBUG] as that is how it should be when logging for TF provider.

Also grant parsing gets more detailed logging to catch errors.