### PR TITLE
Accept double quotes around user when parsing grants

### DIFF
--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -828,7 +828,7 @@ func getMatchingGrant(ctx context.Context, db *sql.DB, desiredGrant MySQLGrant) 
 }
 
 var (
-	kUserOrRoleRegex = regexp.MustCompile("['`]?([^'`]+)['`]?(?:@['`]?([^'`]+)['`]?)?")
+	kUserOrRoleRegex = regexp.MustCompile("['`\"]?([^'`\"]+)['`\"]?(?:@['`\"]?([^'`\"]+)['`\"]?)?")
 )
 
 func parseUserOrRoleFromRow(userOrRoleStr string) (*UserOrRole, error) {
@@ -849,7 +849,7 @@ func parseUserOrRoleFromRow(userOrRoleStr string) (*UserOrRole, error) {
 }
 
 var (
-	kDatabaseAndObjectRegex = regexp.MustCompile("['`]?([^'`]+)['`]?\\.['`]?([^'`]+)['`]?")
+	kDatabaseAndObjectRegex = regexp.MustCompile("['`\"]?([^'`\"]+)['`\"]?\\.['`\"]?([^'`\"]+)['`\"]?")
 )
 
 func parseDatabaseQualifiedObject(objectRef string) (string, string, error) {


### PR DESCRIPTION
This is weird - sometimes, double quotes are used to quote username / password *in some outputs* and only for some IPs. That doesn't look real, but it is what it is.

Let's try this.