### PR TITLE
Check for ALL PRIVILEGES with boundaries. Improve test case for MySQL 8

### DIFF
--- a/mysql/resource_grant.go
+++ b/mysql/resource_grant.go
@@ -1078,7 +1078,7 @@ func normalizeColumnOrder(perm string) string {
 	return fmt.Sprintf("%s(%s)", precursor, partsTogether)
 }
 
-var kReAllPrivileges = regexp.MustCompile(`ALL ?(PRIVILEGES)?`)
+var kReAllPrivileges = regexp.MustCompile(`\bALL ?(PRIVILEGES)?\b`)
 
 func normalizePerms(perms []string) []string {
 	ret := []string{}

--- a/mysql/resource_grant_test.go
+++ b/mysql/resource_grant_test.go
@@ -317,7 +317,9 @@ func TestAccGrantComplexMySQL8(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccPrivilege("mysql_grant.test", "SHOW DATABASES", true, false),
 					testAccPrivilege("mysql_grant.test", "CONNECTION_ADMIN", true, false),
+					testAccPrivilege("mysql_grant.test", "FIREWALL_EXEMPT", true, false),
 					testAccPrivilege("mysql_grant.test", "SELECT", true, false),
+					testAccPrivilege("mysql_grant.test", "ALL PRIVILEGES", false, false),
 				),
 			},
 		},
@@ -616,7 +618,7 @@ resource "mysql_grant" "test" {
   host       = "${mysql_user.test.host}"
   table      = "*"
   database   = "*"
-  privileges = ["SHOW DATABASES", "CONNECTION_ADMIN", "SELECT"]
+  privileges = ["SHOW DATABASES", "CONNECTION_ADMIN", "SELECT", "FIREWALL_EXEMPT"]
 }
 
 `, dbName, dbName)


### PR DESCRIPTION
New grant introduced in MySQL 8 `FIREWALL_EXEMPT` is detected as `ALL PRIVILEGES` due to the regex for detecting all privileges.

This change ensures that `ALL`, `ALLPRIVILEGES` or `ALL PRIVILEGES` is actually found in the list of grants and not other strings containing them.