### PR TITLE
Change collation lookup to be durable across additional engine/versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,5 +38,5 @@ workflows:
       - integration:
           matrix:
             parameters:
-              target: ["testversion5.6", "testversion5.7", "testversion8.0", "testpercona5.7", "testpercona8.0", "testmariadb10.3", "testmariadb10.8", "testmariadb10.10", "testtidb6.1.0"]
+              target: ["testversion5.6", "testversion5.7", "testversion8.0", "testpercona5.7", "testpercona8.0", "testmariadb10.3", "testmariadb10.8", "testmariadb10.10", "testtidb6.1.0", "testtidb7.5.2"]
       - govet

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -58,6 +58,7 @@ testtidb%:
 	$(MAKE) MYSQL_VERSION=$* MYSQL_PORT=34$(shell echo "$*" | tr -d '.') testtidb
 
 testtidb:
+	# WARNING: this does not work as a bare task run, it only instantiates correctly inside the versioned TiDB task run
 	@sh -c "'$(CURDIR)/scripts/tidb-test-cluster.sh' --init --port $(MYSQL_PORT) --version $(MYSQL_VERSION)"
 	@echo 'Waiting for TiDB...'
 	@while ! mysql -h 127.0.0.1 -P $(MYSQL_PORT) -u "$(TEST_USER)" -e 'SELECT 1' >/dev/null 2>&1; do printf '.'; sleep 1; done ; echo ; echo "Connected!"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,7 +22,7 @@ bin/terraform:
 testacc: fmtcheck bin/terraform
 	PATH="$(CURDIR)/bin:${PATH}" TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout=90s
 
-acceptance: testversion5.6 testversion5.7 testversion8.0 testpercona5.7 testpercona8.0 testmariadb10.3 testmariadb10.8 testmariadb10.10 testtidb6.1.0
+acceptance: testversion5.6 testversion5.7 testversion8.0 testpercona5.7 testpercona8.0 testmariadb10.3 testmariadb10.8 testmariadb10.10 testtidb6.1.0 testtidb7.5.2
 
 testversion%:
 	$(MAKE) MYSQL_VERSION=$* MYSQL_PORT=33$(shell echo "$*" | tr -d '.') testversion

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -57,8 +57,9 @@ testrdsdb:
 testtidb%:
 	$(MAKE) MYSQL_VERSION=$* MYSQL_PORT=34$(shell echo "$*" | tr -d '.') testtidb
 
+# WARNING: this does not work as a bare task run, it only instantiates correctly inside the versioned TiDB task run
+#          otherwise MYSQL_PORT and version are unset.
 testtidb:
-	# WARNING: this does not work as a bare task run, it only instantiates correctly inside the versioned TiDB task run
 	@sh -c "'$(CURDIR)/scripts/tidb-test-cluster.sh' --init --port $(MYSQL_PORT) --version $(MYSQL_VERSION)"
 	@echo 'Waiting for TiDB...'
 	@while ! mysql -h 127.0.0.1 -P $(MYSQL_PORT) -u "$(TEST_USER)" -e 'SELECT 1' >/dev/null 2>&1; do printf '.'; sleep 1; done ; echo ; echo "Connected!"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ $ make bin
 $ $GOPATH/bin/terraform-provider-mysql
 ...
 ```
+### Ensure local requirements are present:
+
+1. Docker environment
+2. mysql-client binary which can be installed on Mac with `brew install mysql-client@8.0`
+   1. Then add it to your path OR `brew link mysql-client@8.0`
+
+### Running tests
 
 In order to test the provider, you can simply run `make test`.
 

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -541,6 +541,22 @@ func serverVersionString(db *sql.DB) (string, error) {
 	return versionString, nil
 }
 
+// serverTiDB returns whether it is a TiDB instance
+// and then returns the: tidbVersion, mysqlCompatibilityVersion
+func serverTiDB(db *sql.DB) (bool, string, string, error) {
+	currentVersionString, err := serverVersionString(db)
+	if err != nil {
+		return false, "", "", err
+	}
+
+	if strings.Contains(currentVersionString, "TiDB") {
+		versions := strings.SplitN(currentVersionString, "-", 3)
+		return true, versions[2], versions[0], nil
+	}
+
+	return false, "", "", nil
+}
+
 func serverRds(db *sql.DB) (bool, error) {
 	var metadataVersionString string
 	err := db.QueryRow("SELECT @@GLOBAL.datadir").Scan(&metadataVersionString)

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -541,8 +541,11 @@ func serverVersionString(db *sql.DB) (string, error) {
 	return versionString, nil
 }
 
-// serverTiDB returns whether it is a TiDB instance
-// and then returns the: tidbVersion, mysqlCompatibilityVersion
+// serverTiDB returns:
+// - it is a TiDB instance
+// - tidbVersion
+// - mysqlCompatibilityVersion
+// - err
 func serverTiDB(db *sql.DB) (bool, string, string, error) {
 	currentVersionString, err := serverVersionString(db)
 	if err != nil {

--- a/mysql/provider_test.go
+++ b/mysql/provider_test.go
@@ -190,7 +190,6 @@ func testAccPreCheckSkipNotMySQL8(t *testing.T) {
 
 		t.Skip("Skip on MySQL8")
 	}
-	fmt.Printf(`CURRENT VERSION: %+v\n`, currentVersion)
 }
 
 func testAccPreCheckSkipNotMySQLVersionMin(t *testing.T, minVersion string) {

--- a/mysql/provider_test.go
+++ b/mysql/provider_test.go
@@ -154,6 +154,10 @@ func testAccPreCheckSkipMariaDB(t *testing.T) {
 }
 
 func testAccPreCheckSkipNotMySQL8(t *testing.T) {
+	testAccPreCheckSkipNotMySQLVersionMin(t, "8.0.0")
+}
+
+func testAccPreCheckSkipNotMySQLVersionMin(t *testing.T, minVersion string) {
 	testAccPreCheck(t)
 
 	ctx := context.Background()
@@ -169,7 +173,7 @@ func testAccPreCheckSkipNotMySQL8(t *testing.T) {
 		return
 	}
 
-	versionMin, _ := version.NewVersion("8.0.0")
+	versionMin, _ := version.NewVersion(minVersion)
 	if currentVersion.LessThan(versionMin) {
 		// TiDB 7.x series advertises as 8.0 mysql so we batch its testing strategy with Mysql8
 		isTiDB, tidbVersion, mysqlCompatibilityVersion, err := serverTiDB(db)
@@ -189,28 +193,6 @@ func testAccPreCheckSkipNotMySQL8(t *testing.T) {
 		}
 
 		t.Skip("Skip on MySQL8")
-	}
-}
-
-func testAccPreCheckSkipNotMySQLVersionMin(t *testing.T, minVersion string) {
-	testAccPreCheck(t)
-
-	ctx := context.Background()
-	db, err := connectToMySQL(ctx, testAccProvider.Meta().(*MySQLConfiguration))
-	if err != nil {
-		t.Fatalf("Cannot connect to DB (SkipNotMySQLVersionMin): %v", err)
-		return
-	}
-
-	currentVersion, err := serverVersion(db)
-	if err != nil {
-		t.Fatalf("Cannot get DB version string (SkipNotMySQLVersionMin): %v", err)
-		return
-	}
-
-	versionMin, _ := version.NewVersion(minVersion)
-	if currentVersion.LessThan(versionMin) {
-		t.Skipf("Skip on MySQL version less than %s", minVersion)
 	}
 }
 

--- a/mysql/provider_test.go
+++ b/mysql/provider_test.go
@@ -3,10 +3,11 @@ package mysql
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/go-version"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/go-version"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -170,8 +171,26 @@ func testAccPreCheckSkipNotMySQL8(t *testing.T) {
 
 	versionMin, _ := version.NewVersion("8.0.0")
 	if currentVersion.LessThan(versionMin) {
+		// TiDB 7.x series advertises as 8.0 mysql so we batch its testing strategy with Mysql8
+		isTiDB, tidbVersion, mysqlCompatibilityVersion, err := serverTiDB(db)
+		if err != nil {
+			t.Fatalf("Cannot get DB version string (SkipNotMySQL8): %v", err)
+			return
+		}
+		if isTiDB {
+			mysqlVersion, err := version.NewVersion(mysqlCompatibilityVersion)
+			if err != nil {
+				t.Fatalf("Cannot get DB version string for TiDB (SkipNotMySQL8): %s %s %v", tidbVersion, mysqlCompatibilityVersion, err)
+				return
+			}
+			if mysqlVersion.LessThan(versionMin) {
+				t.Skip("Skip on MySQL8")
+			}
+		}
+
 		t.Skip("Skip on MySQL8")
 	}
+	fmt.Printf(`CURRENT VERSION: %+v\n`, currentVersion)
 }
 
 func testAccPreCheckSkipNotMySQLVersionMin(t *testing.T, minVersion string) {

--- a/mysql/resource_database_test.go
+++ b/mysql/resource_database_test.go
@@ -13,7 +13,7 @@ import (
 func TestAccDatabase(t *testing.T) {
 	dbName := "terraform_acceptance_test"
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheckSkipTiDB(t) },
+		PreCheck:          func() {},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccDatabaseCheckDestroy(dbName),
 		Steps: []resource.TestStep{
@@ -46,7 +46,7 @@ func TestAccDatabase_collationChange(t *testing.T) {
 	ctx := context.Background()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheckSkipTiDB(t) },
+		PreCheck:          func() {},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccDatabaseCheckDestroy(dbName),
 		Steps: []resource.TestStep{

--- a/mysql/resource_default_roles_test.go
+++ b/mysql/resource_default_roles_test.go
@@ -16,7 +16,6 @@ func TestAccDefaultRoles_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckSkipNotMySQL8(t)
 			testAccPreCheckSkipMariaDB(t)
-			testAccPreCheckSkipTiDB(t)
 		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccDefaultRolesCheckDestroy,

--- a/mysql/resource_default_roles_test.go
+++ b/mysql/resource_default_roles_test.go
@@ -16,6 +16,7 @@ func TestAccDefaultRoles_basic(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckSkipNotMySQL8(t)
 			testAccPreCheckSkipMariaDB(t)
+			testAccPreCheckSkipTiDB(t)
 		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccDefaultRolesCheckDestroy,

--- a/mysql/resource_grant_test.go
+++ b/mysql/resource_grant_test.go
@@ -369,6 +369,7 @@ func TestAccGrant_roleToUser(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckSkipRds(t)
 			testAccPreCheckSkipNotMySQLVersionMin(t, "8.0.0")
+			testAccPreCheckSkipTiDB(t)
 		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccGrantCheckDestroy,
@@ -392,6 +393,7 @@ func TestAccGrant_complexRoleGrants(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckSkipMariaDB(t)
 			testAccPreCheckSkipNotMySQLVersionMin(t, "8.0.0")
+			testAccPreCheckSkipTiDB(t) // errors on WITH ADMIN OPTION in v7.5.2
 		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccGrantCheckDestroy,
@@ -1075,12 +1077,12 @@ func TestAllowDuplicateUsersDifferentTables(t *testing.T) {
 	resource "mysql_database" "test" {
 	  name = "%s"
 	}
-	
+
 	resource "mysql_user" "test" {
 	  user     = "jdoe-%s"
 	  host     = "example.com"
 	}
-	
+
 	resource "mysql_grant" "grant1" {
 	  user       = "${mysql_user.test.user}"
 	  host       = "${mysql_user.test.host}"
@@ -1088,7 +1090,7 @@ func TestAllowDuplicateUsersDifferentTables(t *testing.T) {
       table      = "table1"
 	  privileges = ["UPDATE", "SELECT"]
 	}
-	
+
 	resource "mysql_grant" "grant2" {
 	  user       = "${mysql_user.test.user}"
 	  host       = "${mysql_user.test.host}"
@@ -1140,12 +1142,12 @@ func TestDisallowDuplicateUsersSameTable(t *testing.T) {
 	resource "mysql_database" "test" {
 	  name = "%s"
 	}
-	
+
 	resource "mysql_user" "test" {
 	  user     = "jdoe-%s"
 	  host     = "example.com"
 	}
-	
+
 	resource "mysql_grant" "grant1" {
 	  user       = "${mysql_user.test.user}"
 	  host       = "${mysql_user.test.host}"
@@ -1153,7 +1155,7 @@ func TestDisallowDuplicateUsersSameTable(t *testing.T) {
       table      = "table1"
 	  privileges = ["UPDATE", "SELECT"]
 	}
-	
+
 	resource "mysql_grant" "grant2" {
 	  user       = "${mysql_user.test.user}"
 	  host       = "${mysql_user.test.host}"

--- a/mysql/resource_grant_test.go
+++ b/mysql/resource_grant_test.go
@@ -297,7 +297,6 @@ func TestAccGrantComplexMySQL8(t *testing.T) {
 	dbName := fmt.Sprintf("tf-test-%d", rand.Intn(100))
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckSkipTiDB(t)
 			testAccPreCheckSkipRds(t)
 			testAccPreCheckSkipMariaDB(t)
 			testAccPreCheckSkipNotMySQLVersionMin(t, "8.0.0")
@@ -369,7 +368,6 @@ func TestAccGrant_roleToUser(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckSkipRds(t)
 			testAccPreCheckSkipNotMySQLVersionMin(t, "8.0.0")
-			testAccPreCheckSkipTiDB(t)
 		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccGrantCheckDestroy,
@@ -393,7 +391,6 @@ func TestAccGrant_complexRoleGrants(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckSkipMariaDB(t)
 			testAccPreCheckSkipNotMySQLVersionMin(t, "8.0.0")
-			testAccPreCheckSkipTiDB(t) // errors on WITH ADMIN OPTION in v7.5.2
 		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccGrantCheckDestroy,

--- a/mysql/resource_grant_test.go
+++ b/mysql/resource_grant_test.go
@@ -300,6 +300,7 @@ func TestAccGrantComplexMySQL8(t *testing.T) {
 			testAccPreCheckSkipRds(t)
 			testAccPreCheckSkipMariaDB(t)
 			testAccPreCheckSkipNotMySQLVersionMin(t, "8.0.0")
+			testAccPreCheckSkipTiDB(t)
 		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccGrantCheckDestroy,
@@ -368,6 +369,7 @@ func TestAccGrant_roleToUser(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckSkipRds(t)
 			testAccPreCheckSkipNotMySQLVersionMin(t, "8.0.0")
+			testAccPreCheckSkipTiDB(t)
 		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccGrantCheckDestroy,
@@ -391,6 +393,7 @@ func TestAccGrant_complexRoleGrants(t *testing.T) {
 			testAccPreCheck(t)
 			testAccPreCheckSkipMariaDB(t)
 			testAccPreCheckSkipNotMySQLVersionMin(t, "8.0.0")
+			testAccPreCheckSkipTiDB(t)
 		},
 		ProviderFactories: testAccProviderFactories,
 		CheckDestroy:      testAccGrantCheckDestroy,

--- a/mysql/resource_user_test.go
+++ b/mysql/resource_user_test.go
@@ -133,7 +133,6 @@ func TestAccUser_authConnect(t *testing.T) {
 func TestAccUser_authConnectRetainOldPassword(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			testAccPreCheckSkipTiDB(t)
 			testAccPreCheckSkipMariaDB(t)
 			testAccPreCheckSkipRds(t)
 			testAccPreCheckSkipNotMySQLVersionMin(t, "8.0.14")

--- a/scripts/tidb-test-cluster.sh
+++ b/scripts/tidb-test-cluster.sh
@@ -130,7 +130,7 @@ function run_tikv() {
 		-v /etc/localtime:/etc/localtime:ro \
 		-h tikv \
 		--network "$DOCKER_NETWORK" \
-		pingcap/tikv:v4.0.0 \
+		pingcap/tikv:$TAG_VERSION \
 		--addr="0.0.0.0:20160" \
 		--advertise-addr="tikv:20160" \
 		--status-addr="0.0.0.0:20180" \


### PR DESCRIPTION
This patch looks up collation based on INFORMATION_SCHEMA.COLLATIONS and scopes the response to just the two required columns.

The intention is that it will be a more steady reference and interface because we're able to select only the required columns rather than breaking when new columns are added to the interface for `SHOW COLLATION...`.

Context: using this provider broke for v7.5 of TiDB but I think there's a more durable approach by looking up directly the columns needed (more below).

This patch uses that `INFORMATION_SCHEMA.COLLATIONS` lookup to be compatible with the following:
1. Mysql 5.7 and 8.0 without special casing
2. MariaDB without special casing (assumed base on prior compatibility)
3. compatible with TiDB for 6.x and 7.x (v7.5.1 which advertises as 8.0.11-TiDB-v7.5.1 but lacks the 7th column in SHOW statement previously used)

To Merge:
- [x] Confirm tests pass (local regressions with 5.7, 8.0 and tidb 6.5 and 7.5 worked)
- [x] Check if MariaDB has any breaking behavior that would invalidate these assumptions about COLLATIONS table (tests passing there)