### PR TITLE
Fix: hide mysql_user_password.cleartext_password in plan/apply output

### DIFF
--- a/mysql/resource_user_password.go
+++ b/mysql/resource_user_password.go
@@ -3,8 +3,9 @@ package mysql
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
 	"github.com/gofrs/uuid"
 	"github.com/hashicorp/go-version"
@@ -30,8 +31,9 @@ func resourceUserPassword() *schema.Resource {
 				Default:  "localhost",
 			},
 			"plaintext_password": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Optional:  true,
 			},
 
 			"retain_old_password": {


### PR DESCRIPTION
Currently, the password is printed out in apply/plan even when rotated.
The attribute can't be set to sensitive, and if using Atlantis, the existing password will appear in PRs where it is automated. 
if apply fails, it means that the active password was exposed

**How to reproduce**
```hcl
# providers.tf
terraform {
  required_version = "~> 1.0"

  required_providers {
    mysql = {
      source  = "petoju/mysql"
      version = "3.0.62"
    }
  }
}

# main.tf
resource "mysql_user" "app_user" {
  user        = "test_user"
  host        = "%"
  tls_option  = "SSL"
  auth_plugin = "caching_sha2_password"
}

resource "mysql_user_password" "app_user_password" {
  user = mysql_user.app_user.user
  host = mysql_user.app_user.host
}

output "plaintext_password" {
  sensitive = true
  value     = mysql_user_password.app_user_password.plaintext_password
}
```
**Then run**
```shell
❯ tf -version
Terraform v1.9.2
on darwin_arm64
+ provider registry.terraform.io/petoju/mysql v3.0.62

❯ tf plan
mysql_user.app_user: Refreshing state... [id=test_user@%]
mysql_user_password.app_user_password: Refreshing state... [id=test_user@%]

Terraform used the selected providers to generate
the following execution plan. Resource actions are
indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # mysql_user_password.app_user_password will be updated in-place
  ~ resource "mysql_user_password" "app_user_password" {
        id                 = "test_user@%"
      - plaintext_password = "39a8c62e-7e5d-4f4d-b212-6e4c34ffd6c3" -> null
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

❯ tf apply
mysql_user.app_user: Refreshing state... [id=test_user@%]
mysql_user_password.app_user_password: Refreshing state... [id=test_user@%]

Terraform used the selected providers to generate
the following execution plan. Resource actions are
indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # mysql_user_password.app_user_password will be updated in-place
  ~ resource "mysql_user_password" "app_user_password" {
        id                 = "test_user@%"
      - plaintext_password = "3cd4882c-c303-44d3-ad8a-3d611c56814b" -> null
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Changes to Outputs:
  + plaintext_password = (sensitive value)

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

mysql_user_password.app_user_password: Modifying... [id=test_user@%]
mysql_user_password.app_user_password: Modifications complete after 2s [id=test_user@%]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

plaintext_password = <sensitive>
```
**Second apply (rotates password)**
```shell
❯ tf apply
mysql_user.app_user: Refreshing state... [id=test_user@%]
mysql_user_password.app_user_password: Refreshing state... [id=test_user@%]

Terraform used the selected providers to generate
the following execution plan. Resource actions are
indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # mysql_user_password.app_user_password will be updated in-place
  ~ resource "mysql_user_password" "app_user_password" {
        id                 = "test_user@%"
      - plaintext_password = "ee9ae04a-0f1c-48c4-80e5-630540eca339" -> null
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

mysql_user_password.app_user_password: Modifying... [id=test_user@%]
mysql_user_password.app_user_password: Modifications complete after 2s [id=test_user@%]

Apply complete! Resources: 0 added, 1 changed, 0 destroyed.

Outputs:

plaintext_password = <sensitive>
```

After building the version in this PR the issue is solved and the password is hidden in both plan and apply commands
```shell
❯ tf plan
mysql_user.app_user: Refreshing state... [id=test_user@%]
mysql_user_password.app_user_password: Refreshing state... [id=test_user@%]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # mysql_user_password.app_user_password will be updated in-place
  ~ resource "mysql_user_password" "app_user_password" {
        id                 = "test_user@%"
      - plaintext_password = (sensitive value) -> null
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.

❯ tf apply
mysql_user.app_user: Refreshing state... [id=test_user@%]
mysql_user_password.app_user_password: Refreshing state... [id=test_user@%]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # mysql_user_password.app_user_password will be updated in-place
  ~ resource "mysql_user_password" "app_user_password" {
        id                 = "test_user@%"
      - plaintext_password = (sensitive value) -> null
        # (2 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```