### PR TITLE
Fixed the GoReleaser error "only version 2 configuration files are supported"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing


### PR DESCRIPTION
GoReleaser v2.8.2 gave 'error only version: 2 configuration files are supported, yours is version: 0, please update your configuration' unless the version was explicitly specified in the YAML file. 

Without adding `version: 2` to the YAML file, you could not compile the terraform-provider-mysql