### PR TITLE
feat: connection pooling

### DIFF
--- a/mysql/connection_wrapper.go
+++ b/mysql/connection_wrapper.go
@@ -1,0 +1,98 @@
+package mysql
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/go-version"
+)
+
+// sessionInitializingConnector wraps a driver.Connector to initialize session settings
+// on each new connection that is created from the pool.
+type sessionInitializingConnector struct {
+	base         driver.Connector
+	sqlModeQuery string
+	version      *version.Version
+	versionMu    sync.RWMutex
+}
+
+// Connect returns a connection to the database.
+// Connect may return a cached connection (one previously
+// closed), but doing so is unnecessary; the sql package
+// maintains a pool of idle connections for efficient re-use.
+//
+// The provided context.Context is for dialing purposes only
+// (see net.DialContext) and should not be stored or used for
+// other purposes. A default timeout should still be used
+// when dialing as a connection pool may call Connect
+// asynchronously to any query.
+//
+// The returned connection is only used by one goroutine at a
+// time.
+func (c *sessionInitializingConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	conn, err := c.base.Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the version once
+	c.versionMu.RLock()
+	ver := c.version
+	c.versionMu.RUnlock()
+
+	if ver != nil && c.sqlModeQuery != "" {
+		// Apply session settings to the connection
+		if err := c.applySessionModeToConnection(ctx, conn); err != nil {
+			conn.Close()
+			return nil, fmt.Errorf("failed to set session sql_mode: %v", err)
+		}
+	}
+
+	return conn, nil
+}
+
+// Driver returns the underlying Driver of the Connector,
+// mainly to maintain compatibility with the Driver method
+// on sql.DB.
+func (c *sessionInitializingConnector) Driver() driver.Driver {
+	return c.base.Driver()
+}
+
+func (c *sessionInitializingConnector) setVersion(v *version.Version) {
+	c.versionMu.Lock()
+	defer c.versionMu.Unlock()
+	c.version = v
+
+	c.sqlModeQuery = getSQLModeForConnection(v)
+}
+
+// applySessionModeToConnection executes the SQL mode session statement on the given connection.
+func (c *sessionInitializingConnector) applySessionModeToConnection(ctx context.Context, conn driver.Conn) error {
+	if execer, ok := conn.(driver.ExecerContext); ok {
+		_, err := execer.ExecContext(ctx, c.sqlModeQuery, nil)
+		return err
+	} else if execerOld, ok := conn.(driver.Execer); ok {
+		_, err := execerOld.Exec(c.sqlModeQuery, nil)
+		return err
+	} else {
+		return errors.New("connection does not support Exec or ExecContext for setting session sql_mode")
+	}
+}
+
+// getSQLModeForConnection returns the appropriate SQL mode session statement based on the MySQL version.
+func getSQLModeForConnection(v *version.Version) string {
+	// Return the SQL mode statement based on version
+	versionMinInclusive, _ := version.NewVersion("5.7.5")
+	versionMaxExclusive, _ := version.NewVersion("8.0.0")
+	if v.GreaterThanOrEqual(versionMinInclusive) && v.LessThan(versionMaxExclusive) {
+		// We set NO_AUTO_CREATE_USER to prevent provider from creating user when creating grants. Newer MySQL has it automatically.
+		// We don't want any other modes, esp. not ANSI_QUOTES.
+		return `SET SESSION sql_mode='NO_AUTO_CREATE_USER'`
+	}
+
+	// We don't want any modes, esp. not ANSI_QUOTES.
+	return `SET SESSION sql_mode=''`
+}

--- a/mysql/connection_wrapper_test.go
+++ b/mysql/connection_wrapper_test.go
@@ -1,0 +1,427 @@
+package mysql
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+)
+
+// mockConnector is a mock implementation of driver.Connector for testing
+type mockConnector struct {
+	connectCount int
+	mu           sync.Mutex
+	conn         *mockConn
+	allConns     []*mockConn // Track all connections created
+	connectErr   error
+}
+
+func (m *mockConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.connectCount++
+	if m.connectErr != nil {
+		return nil, m.connectErr
+	}
+	conn := &mockConn{
+		execCount: 0,
+	}
+	m.conn = conn
+	m.allConns = append(m.allConns, conn)
+	return conn, nil
+}
+
+func (m *mockConnector) Driver() driver.Driver {
+	return &mockDriver{}
+}
+
+func (m *mockConnector) getConnectCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.connectCount
+}
+
+func (m *mockConnector) getAllConns() []*mockConn {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	result := make([]*mockConn, len(m.allConns))
+	copy(result, m.allConns)
+	return result
+}
+
+// mockConn is a mock implementation of driver.Conn for testing
+type mockConn struct {
+	execCount  int
+	execQuery  string
+	mu         sync.Mutex
+	closed     bool
+	prepCount  int
+	beginCount int
+}
+
+func (m *mockConn) Exec(query string, args []driver.Value) (driver.Result, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.execCount++
+	m.execQuery = query
+	return &mockResult{}, nil
+}
+
+func (m *mockConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.execCount++
+	m.execQuery = query
+	return &mockResult{}, nil
+}
+
+func (m *mockConn) Prepare(query string) (driver.Stmt, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.prepCount++
+	if m.closed {
+		return nil, errors.New("connection closed")
+	}
+	return &mockStmt{}, nil
+}
+
+func (m *mockConn) Close() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	return nil
+}
+
+func (m *mockConn) Begin() (driver.Tx, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.beginCount++
+	if m.closed {
+		return nil, errors.New("connection closed")
+	}
+	return &mockTx{}, nil
+}
+
+func (m *mockConn) getExecCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.execCount
+}
+
+func (m *mockConn) getExecQuery() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.execQuery
+}
+
+// mockResult, mockStmt, mockTx, mockDriver are minimal implementations
+type mockResult struct{}
+
+func (m *mockResult) LastInsertId() (int64, error) { return 0, nil }
+func (m *mockResult) RowsAffected() (int64, error) { return 0, nil }
+
+type mockStmt struct{}
+
+func (m *mockStmt) Close() error                                    { return nil }
+func (m *mockStmt) NumInput() int                                   { return 0 }
+func (m *mockStmt) Exec(args []driver.Value) (driver.Result, error) { return &mockResult{}, nil }
+func (m *mockStmt) Query(args []driver.Value) (driver.Rows, error)  { return nil, nil }
+
+type mockTx struct{}
+
+func (m *mockTx) Commit() error   { return nil }
+func (m *mockTx) Rollback() error { return nil }
+
+type mockDriver struct{}
+
+func (m *mockDriver) Open(name string) (driver.Conn, error) { return &mockConn{}, nil }
+
+// TestSessionInitializingConnector_SetsSessionOnEachConnection tests that
+// the sessionInitializingConnector applies session settings to each new connection.
+func TestSessionInitializingConnector_SetsSessionOnEachConnection(t *testing.T) {
+	// Create a version for MySQL 5.7.x (should use NO_AUTO_CREATE_USER)
+	v, _ := version.NewVersion("5.7.10")
+
+	mckCnctr := &mockConnector{}
+
+	connector := &sessionInitializingConnector{
+		base: mckCnctr,
+	}
+	connector.setVersion(v)
+
+	expectedQuery := `SET SESSION sql_mode='NO_AUTO_CREATE_USER'`
+
+	// Create multiple connections and verify each gets session settings
+	conn1, err := connector.Connect(t.Context())
+	if err != nil {
+		t.Fatalf("Connect() failed: %v", err)
+	}
+	if conn1 == nil {
+		t.Fatal("Connect() returned nil connection")
+	}
+
+	// Create a second connection
+	conn2, err := connector.Connect(t.Context())
+	if err != nil {
+		t.Fatalf("Connect() for second connection failed: %v", err)
+	}
+
+	// Create a third connection
+	conn3, err := connector.Connect(t.Context())
+	if err != nil {
+		t.Fatalf("Connect() for third connection failed: %v", err)
+	}
+
+	// Verify that Connect was called 3 times on the base connector
+	if mckCnctr.getConnectCount() != 3 {
+		t.Errorf("Expected 3 base connector calls, got %d", mckCnctr.getConnectCount())
+	}
+
+	// Get all connections and verify each one got session settings
+	allConns := mckCnctr.getAllConns()
+	if len(allConns) != 3 {
+		t.Fatalf("Expected 3 connections to be tracked, got %d", len(allConns))
+	}
+
+	for i, conn := range allConns {
+		if conn.getExecCount() != 1 {
+			t.Errorf("Connection %d: expected 1 exec call, got %d", i, conn.getExecCount())
+		}
+		if conn.getExecQuery() != expectedQuery {
+			t.Errorf("Connection %d: expected query %q, got %q", i, expectedQuery, conn.getExecQuery())
+		}
+	}
+
+	// Verify connections are different objects
+	if conn1 == conn2 || conn2 == conn3 || conn1 == conn3 {
+		t.Error("Expected different connection objects")
+	}
+}
+
+// TestSessionInitializingConnector_MySQL8EmptySQLMode tests that
+// MySQL 8.x uses empty sql_mode.
+func TestSessionInitializingConnector_MySQL8EmptySQLMode(t *testing.T) {
+	v, _ := version.NewVersion("8.0.25")
+
+	mckCnctr := &mockConnector{}
+
+	connector := &sessionInitializingConnector{
+		base: mckCnctr,
+	}
+	connector.setVersion(v)
+
+	_, err := connector.Connect(t.Context())
+	if err != nil {
+		t.Fatalf("Connect() failed: %v", err)
+	}
+
+	expectedQuery := `SET SESSION sql_mode=''`
+	innerConn := mckCnctr.conn
+	if innerConn.getExecQuery() != expectedQuery {
+		t.Errorf("Expected query %q, got %q", expectedQuery, innerConn.getExecQuery())
+	}
+}
+
+// TestSessionInitializingConnector_MySQL57EmptySession tests that
+// MySQL 5.7.4 and earlier uses empty sql_mode (before NO_AUTO_CREATE_USER default).
+func TestSessionInitializingConnector_MySQL57EmptySession(t *testing.T) {
+	v, _ := version.NewVersion("5.7.4")
+
+	mckCnctr := &mockConnector{}
+
+	connector := &sessionInitializingConnector{
+		base: mckCnctr,
+	}
+	connector.setVersion(v)
+
+	_, err := connector.Connect(t.Context())
+	if err != nil {
+		t.Fatalf("Connect() failed: %v", err)
+	}
+
+	expectedQuery := `SET SESSION sql_mode=''`
+	innerConn := mckCnctr.conn
+	if innerConn.getExecQuery() != expectedQuery {
+		t.Errorf("Expected query %q, got %q", expectedQuery, innerConn.getExecQuery())
+	}
+}
+
+// TestSessionInitializingConnector_NoVersion tests that
+// when version is nil, no session query is executed.
+func TestSessionInitializingConnector_NoVersion(t *testing.T) {
+	mckCnctr := &mockConnector{}
+
+	connector := &sessionInitializingConnector{
+		base: mckCnctr,
+	}
+	// Don't set version
+
+	conn, err := connector.Connect(t.Context())
+	if err != nil {
+		t.Fatalf("Connect() failed: %v", err)
+	}
+
+	// Connection should still be created
+	if conn == nil {
+		t.Fatal("Expected non-nil connection")
+	}
+
+	// But no exec should have been called
+	innerConn := mckCnctr.conn
+	if innerConn.getExecCount() != 0 {
+		t.Errorf("Expected 0 exec calls when version is nil, got %d", innerConn.getExecCount())
+	}
+}
+
+// TestSessionInitializingConnector_BaseConnectError tests that
+// errors from the base connector are propagated.
+func TestSessionInitializingConnector_BaseConnectError(t *testing.T) {
+	expectedErr := errors.New("connection failed")
+
+	mckCnctr := &mockConnector{
+		connectErr: expectedErr,
+	}
+
+	connector := &sessionInitializingConnector{
+		base: mckCnctr,
+	}
+	v, _ := version.NewVersion("8.0.0")
+	connector.setVersion(v)
+
+	_, err := connector.Connect(t.Context())
+	if err == nil {
+		t.Fatal("Expected error from base connector")
+	}
+	if !errors.Is(err, expectedErr) {
+		t.Errorf("Expected error %v, got %v", expectedErr, err)
+	}
+}
+
+// TestSessionInitializingConnector_ExecErrorClosesConn tests that
+// when session exec fails, the connection is closed.
+func TestSessionInitializingConnector_ExecErrorClosesConn(t *testing.T) {
+	// Create a mock connection that fails on exec
+	mckCnctr := &mockConnectorWithFailingExec{}
+
+	connector := &sessionInitializingConnector{
+		base: mckCnctr,
+	}
+	v, _ := version.NewVersion("8.0.0")
+	connector.setVersion(v)
+
+	_, err := connector.Connect(t.Context())
+	if err == nil {
+		t.Fatal("Expected error from session exec")
+	}
+
+	// Verify the connection was closed
+	if !mckCnctr.conn.closed {
+		t.Error("Expected connection to be closed after exec failure")
+	}
+}
+
+// mockConnectorWithFailingExec creates connections that fail on exec
+type mockConnectorWithFailingExec struct {
+	conn *mockConnFailingExec
+}
+
+func (m *mockConnectorWithFailingExec) Connect(ctx context.Context) (driver.Conn, error) {
+	m.conn = &mockConnFailingExec{}
+	return m.conn, nil
+}
+
+func (m *mockConnectorWithFailingExec) Driver() driver.Driver {
+	return &mockDriver{}
+}
+
+// mockConnFailingExec fails on exec
+type mockConnFailingExec struct {
+	closed bool
+}
+
+func (m *mockConnFailingExec) Exec(query string, args []driver.Value) (driver.Result, error) {
+	return nil, errors.New("exec failed")
+}
+
+func (m *mockConnFailingExec) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	return nil, errors.New("exec failed")
+}
+
+func (m *mockConnFailingExec) Prepare(query string) (driver.Stmt, error) { return nil, nil }
+func (m *mockConnFailingExec) Close() error {
+	m.closed = true
+	return nil
+}
+func (m *mockConnFailingExec) Begin() (driver.Tx, error) { return nil, nil }
+
+// TestGetSQLModeForConnection tests the version-based SQL mode logic.
+func TestGetSQLModeForConnection(t *testing.T) {
+	testCases := []struct {
+		name            string
+		version         string
+		expectedSQLMode string
+	}{
+		{
+			name:            "MySQL 5.6.x - before NO_AUTO_CREATE_USER",
+			version:         "5.6.45",
+			expectedSQLMode: `SET SESSION sql_mode=''`,
+		},
+		{
+			name:            "MySQL 5.7.4 - just before NO_AUTO_CREATE_USER",
+			version:         "5.7.4",
+			expectedSQLMode: `SET SESSION sql_mode=''`,
+		},
+		{
+			name:            "MySQL 5.7.5 - first version with NO_AUTO_CREATE_USER",
+			version:         "5.7.5",
+			expectedSQLMode: `SET SESSION sql_mode='NO_AUTO_CREATE_USER'`,
+		},
+		{
+			name:            "MySQL 5.7.30 - within NO_AUTO_CREATE_USER range",
+			version:         "5.7.30",
+			expectedSQLMode: `SET SESSION sql_mode='NO_AUTO_CREATE_USER'`,
+		},
+		{
+			name:            "MySQL 5.7.999 - last version before 8.0",
+			version:         "5.7.999",
+			expectedSQLMode: `SET SESSION sql_mode='NO_AUTO_CREATE_USER'`,
+		},
+		{
+			name:            "MySQL 8.0.0 - NO_AUTO_CREATE_USER removed",
+			version:         "8.0.0",
+			expectedSQLMode: `SET SESSION sql_mode=''`,
+		},
+		{
+			name:            "MySQL 8.0.25 - current version",
+			version:         "8.0.25",
+			expectedSQLMode: `SET SESSION sql_mode=''`,
+		},
+		{
+			name:            "MySQL 8.4.0 - latest",
+			version:         "8.4.0",
+			expectedSQLMode: `SET SESSION sql_mode=''`,
+		},
+		{
+			name:            "MySQL 9.0.0 - future version",
+			version:         "9.0.0",
+			expectedSQLMode: `SET SESSION sql_mode=''`,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			v, err := version.NewVersion(tc.version)
+			if err != nil {
+				t.Fatalf("Failed to parse version: %v", err)
+			}
+
+			result := getSQLModeForConnection(v)
+			if result != tc.expectedSQLMode {
+				t.Errorf("Expected SQL mode %q, got %q", tc.expectedSQLMode, result)
+			}
+		})
+	}
+}

--- a/mysql/provider.go
+++ b/mysql/provider.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
+	"database/sql/driver"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -677,34 +678,6 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	return mysqlConf, nil
 }
 
-func afterConnectVersion(ctx context.Context, mysqlConf *MySQLConfiguration, db *sql.DB) (*version.Version, error) {
-	// Set up env so that we won't create users randomly.
-	currentVersion, err := serverVersion(db)
-	if err != nil {
-		return nil, fmt.Errorf("failed getting server version: %v", err)
-	}
-
-	versionMinInclusive, _ := version.NewVersion("5.7.5")
-	versionMaxExclusive, _ := version.NewVersion("8.0.0")
-	if currentVersion.GreaterThanOrEqual(versionMinInclusive) &&
-		currentVersion.LessThan(versionMaxExclusive) {
-		// We set NO_AUTO_CREATE_USER to prevent provider from creating user when creating grants. Newer MySQL has it automatically.
-		// We don't want any other modes, esp. not ANSI_QUOTES.
-		_, err = db.ExecContext(ctx, `SET SESSION sql_mode='NO_AUTO_CREATE_USER'`)
-		if err != nil {
-			return nil, fmt.Errorf("failed setting SQL mode: %v", err)
-		}
-	} else {
-		// We don't want any modes, esp. not ANSI_QUOTES.
-		_, err = db.ExecContext(ctx, `SET SESSION sql_mode=''`)
-		if err != nil {
-			return nil, fmt.Errorf("failed setting SQL mode: %v", err)
-		}
-	}
-
-	return currentVersion, nil
-}
-
 var identQuoteReplacer = strings.NewReplacer("`", "``")
 
 // httpProxyDialer implements the proxy.Dialer interface for HTTP proxies
@@ -1020,16 +993,78 @@ func createNewConnection(ctx context.Context, conf *MySQLConfiguration) (*OneCon
 	if retryError != nil {
 		return nil, fmt.Errorf("could not connect to server: %s", retryError)
 	}
+
+	currentVersion, err := serverVersion(db)
+	if err != nil {
+		return nil, fmt.Errorf("failed getting server version: %v", err)
+	}
+
+	// Close the temporary connection - we'll create a proper pooled one
+	db.Close()
+
+	// Create the base connector using the mysql driver's DriverContext interface
+	// This allows us to create a connector that we can wrap with session initialization
+	var baseConnector driver.Connector
+
+	mysqlDrv, ok := interface{}(&mysql.MySQLDriver{}).(driver.DriverContext)
+	if driverName == "mysql" && ok {
+		baseConnector, err = mysqlDrv.OpenConnector(conf.Config.FormatDSN())
+		if err != nil {
+			// If we can't create a custom connector, fall back to standard sql.Open
+			// with limited pooling (the old behavior)
+			db, err = sql.Open(driverName, conf.Config.FormatDSN())
+			if err != nil {
+				return nil, fmt.Errorf("could not open database: %v", err)
+			}
+			db.SetConnMaxLifetime(conf.MaxConnLifetime)
+			db.SetMaxOpenConns(1)
+			if _, err := db.ExecContext(ctx, getSQLModeForConnection(currentVersion)); err != nil {
+				db.Close()
+				return nil, fmt.Errorf("failed to set session sql_mode: %w", err)
+			}
+			return &OneConnection{
+				Db:      db,
+				Version: currentVersion,
+			}, nil
+		}
+	} else {
+		// For cloudsql or if mysql driver doesn't implement DriverContext,
+		// use standard sql.Open with limited pooling
+		db, err = sql.Open(driverName, conf.Config.FormatDSN())
+		if err != nil {
+			return nil, fmt.Errorf("could not open database: %v", err)
+		}
+		db.SetConnMaxLifetime(conf.MaxConnLifetime)
+		// limited pooling because we can't guarantee session initialization for
+		// each connection without a custom connector.
+		db.SetMaxOpenConns(1)
+		if _, err := db.ExecContext(ctx, getSQLModeForConnection(currentVersion)); err != nil {
+			db.Close()
+			return nil, fmt.Errorf("failed to set session sql_mode: %w", err)
+		}
+		return &OneConnection{
+			Db:      db,
+			Version: currentVersion,
+		}, nil
+	}
+
+	// Wrap the connector with session initialization
+	sessionConnector := &sessionInitializingConnector{
+		base: baseConnector,
+	}
+	sessionConnector.setVersion(currentVersion)
+
+	// Open the database with our custom connector
+	db = sql.OpenDB(sessionConnector)
 	db.SetConnMaxLifetime(conf.MaxConnLifetime)
 
-	// We used to set conf.MaxOpenConns, but then some connections are open outside our control
-	// and without our settings like no ANSI_QUOTES.
-	// TODO: find a way to support more open connections while able to set custom settings for each of them.
-	db.SetMaxOpenConns(1)
-
-	currentVersion, err := afterConnectVersion(ctx, conf, db)
-	if err != nil {
-		return nil, fmt.Errorf("failed running after connect command: %v", err)
+	// Enable connection pooling with configured max connections
+	// The sessionInitializingConnector ensures each pooled connection has proper session settings
+	if conf.MaxOpenConns > 0 {
+		db.SetMaxOpenConns(conf.MaxOpenConns)
+	} else {
+		// Default to a reasonable pool size if not configured
+		db.SetMaxOpenConns(10)
 	}
 
 	return &OneConnection{


### PR DESCRIPTION
- Add connection pooling support to the MySQL provider, allowing multiple connections to be open and reused with proper session initialisation for each connection.
- Implement a connection wrapper that applies necessary session settings (like SQL mode) to each connection when it's first used from the pool.
- Update provider configuration to allow setting max open connections and max connection lifetime for better performance and resource management.